### PR TITLE
fix(security): 0.4.4 — workflow permissions blocks (deferred from 0.4.3)

### DIFF
--- a/.github/workflows/chaos.yml
+++ b/.github/workflows/chaos.yml
@@ -11,6 +11,12 @@ on:
   schedule:
     - cron: '0 5 * * 1'  # Monday 05:00 UTC, 1h after vendor-sync cron
 
+# Least-privilege default token: checkout needs contents:read, artifact
+# upload uses the independent ACTIONS_RUNTIME_TOKEN. No write scopes required.
+# Closes CodeQL actions/missing-workflow-permissions #78.
+permissions:
+  contents: read
+
 jobs:
   chaos:
     strategy:

--- a/.github/workflows/e2e-real-webview.yml
+++ b/.github/workflows/e2e-real-webview.yml
@@ -13,6 +13,12 @@ on:
   schedule:
     - cron: '0 4 * * 1' # Monday 04:00 UTC — 1h before chaos.yml
 
+# Least-privilege default token: checkout needs contents:read, artifact
+# upload uses the independent ACTIONS_RUNTIME_TOKEN. No write scopes required.
+# Closes CodeQL actions/missing-workflow-permissions #79.
+permissions:
+  contents: read
+
 jobs:
   e2e-real-webview:
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to Pan-Agent will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.4] - 2026-04-17
+
+Completes the 0.4.3 security-scanner pass. No runtime behaviour change —
+ships only the two workflow-permission blocks that were deferred from 0.4.3
+because the release bot token lacked the `workflow` OAuth scope.
+
+### Security
+- **Workflow least-privilege `permissions:` blocks** added to
+  `.github/workflows/chaos.yml` and `.github/workflows/e2e-real-webview.yml`:
+  ```yaml
+  permissions:
+    contents: read
+  ```
+  `contents: read` is the minimum needed for `actions/checkout@v4`; artifact
+  upload uses the independent `ACTIONS_RUNTIME_TOKEN` so no write scopes are
+  required. Closes CodeQL `actions/missing-workflow-permissions` #78 and
+  #79 (MEDIUM).
+
 ## [0.4.3] - 2026-04-17
 
 Security scanner follow-up on 0.4.2. Clears 11 outstanding alerts on `main`

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pan-desktop",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Pan Desktop — Tauri desktop app for Pan-Agent",
   "productName": "Pan Desktop",
   "author": "Euraika Labs",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -2230,7 +2230,7 @@ dependencies = [
 
 [[package]]
 name = "pan-desktop"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "serde",
  "serde_json",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pan-desktop"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 
 [dependencies]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Pan Desktop",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "identifier": "net.euraika.pandesktop",
   "build": {
     "frontendDist": "../dist",

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -9,7 +9,7 @@ package version
 
 // Version is the semantic version string (e.g. "0.4.0").
 // Overridden via -ldflags at build time.
-var Version = "0.4.3"
+var Version = "0.4.4"
 
 // Commit is the short Git commit hash at build time.
 // Overridden via -ldflags at build time.


### PR DESCRIPTION
## Summary
- Adds workflow-scoped `permissions: contents: read` blocks to `chaos.yml` and `e2e-real-webview.yml` (closes CodeQL #78, #79).
- Deferred from v0.4.3 because the release bot OAuth token lacked the `workflow` scope at the time.
- Bumps all five version sources (Go, desktop package.json, tauri.conf.json, Cargo.toml, Cargo.lock) to 0.4.4.

## Test plan
- [x] CI green on all platforms
- [x] CodeQL alerts #78 and #79 auto-closed after merge