### PR TITLE
WS#5 macOS permission onboarding wizard (Phase 12 v0.5.0 ship-gate)

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -365,6 +365,19 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-graphics"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation",
+ "core-graphics-types",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
@@ -2232,6 +2245,8 @@ dependencies = [
 name = "pan-desktop"
 version = "0.5.0"
 dependencies = [
+ "core-foundation",
+ "core-graphics 0.24.0",
  "serde",
  "serde_json",
  "tauri",
@@ -3595,7 +3610,7 @@ dependencies = [
  "bitflags 2.11.0",
  "block2",
  "core-foundation",
- "core-graphics",
+ "core-graphics 0.25.0",
  "crossbeam-channel",
  "dispatch2",
  "dlopen2",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -10,5 +10,13 @@ tauri-plugin-updater = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
+# Phase 12 WS#5 — macOS permission probes for the Setup wizard.
+# core-graphics provides CGPreflight/RequestScreenCaptureAccess; the
+# AXIsProcessTrusted symbol is declared via a small extern block in
+# permissions.rs (no crate covers it stably).
+[target.'cfg(target_os = "macos")'.dependencies]
+core-graphics = "0.24"
+core-foundation = "0.10"
+
 [build-dependencies]
 tauri-build = { version = "2", features = [] }

--- a/desktop/src-tauri/Info.plist
+++ b/desktop/src-tauri/Info.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!--
+    Phase 12 WS#5 — Apple TCC usage descriptions.
+
+    These strings are surfaced in the system permission prompts the
+    first time Pan-Agent triggers a TCC class. Without them, macOS
+    silently fails the request (or in newer SDKs throws TCC errors
+    that look like the prompt was denied).
+
+    Apple guidance: keep each description user-focused and
+    action-oriented. The reviewer for App Store submissions rejects
+    boilerplate ("for app functionality") so we explain *what we do*.
+  -->
+  <key>NSAppleEventsUsageDescription</key>
+  <string>Pan-Agent uses Apple Events to drive scriptable apps you choose (Finder, Mail, Calendar, etc.) when you ask the agent to perform tasks in them.</string>
+
+  <key>NSScreenCaptureUsageDescription</key>
+  <string>Pan-Agent captures your screen so the visual tools can see what you see and act on it. Captures stay on your machine and are HMAC-redacted before being journaled.</string>
+
+  <key>NSAccessibilityUsageDescription</key>
+  <string>Pan-Agent uses Accessibility APIs to read window titles and click UI elements when you ask the agent to drive other applications.</string>
+
+  <key>NSSystemAdministrationUsageDescription</key>
+  <string>Pan-Agent may request Full Disk Access lazily — only when an action you've authorized needs to write to a TCC-protected location (e.g., ~/Library, ~/Desktop).</string>
+</dict>
+</plist>

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -1,6 +1,8 @@
 // Prevents an additional console window on Windows in release builds.
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+mod permissions;
+
 use std::sync::Mutex;
 
 use tauri::{Manager, RunEvent};
@@ -14,6 +16,11 @@ fn main() {
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
+        .invoke_handler(tauri::generate_handler![
+            permissions::permissions_probe,
+            permissions::permissions_request_screen_recording,
+            permissions::permissions_open_settings,
+        ])
         .setup(|app| {
             let parent_pid = std::process::id().to_string();
 

--- a/desktop/src-tauri/src/permissions.rs
+++ b/desktop/src-tauri/src/permissions.rs
@@ -1,0 +1,240 @@
+//! Phase 12 WS#5 — macOS permission onboarding wizard backend.
+//!
+//! Probes the four TCC classes that Pan-Agent's tools need on macOS:
+//!
+//! | Permission        | Probe                                              | Block-until-granted? |
+//! |-------------------|----------------------------------------------------|----------------------|
+//! | Accessibility     | `AXIsProcessTrustedWithOptions(NULL)`              | yes                  |
+//! | Screen Recording  | `CGPreflightScreenCaptureAccess()`                 | yes                  |
+//! | Automation        | `osascript` no-op + `-1743` error matching         | optional             |
+//! | Full Disk Access  | `fs::metadata("~/Library/Safari/Bookmarks.plist")` | lazy (heuristic)     |
+//!
+//! Public TCC APIs only — no `TCC.db` queries. Per Phase 12 design
+//! decision I5, the SIP-protected database has been unreliable since
+//! macOS 14 even with FDA, so this module avoids it entirely.
+//!
+//! All FFI is gated behind `#[cfg(target_os = "macos")]`; on every
+//! other platform the commands return `Granted` so the wizard step
+//! becomes a no-op (the React side hides itself anyway).
+
+use serde::Serialize;
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PermStatus {
+    Granted,
+    Denied,
+    NotDetermined,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PermissionsReport {
+    pub accessibility: PermStatus,
+    pub screen_recording: PermStatus,
+    pub automation: PermStatus,
+    pub full_disk: PermStatus,
+    /// True on platforms where TCC doesn't apply (Linux, Windows). The
+    /// React side reads this and skips the wizard step.
+    pub platform_supported: bool,
+}
+
+// ---------------------------------------------------------------------------
+// macOS implementation
+// ---------------------------------------------------------------------------
+
+#[cfg(target_os = "macos")]
+mod imp {
+    use super::*;
+    use core_foundation::base::TCFType;
+    use core_foundation::dictionary::CFDictionary;
+    use std::process::Command;
+
+    extern "C" {
+        // Accessibility
+        // The non-prompting variant: pass NULL for options. The prompting
+        // variant exists too (kAXTrustedCheckOptionPrompt -> true) but
+        // we run it from the React Grant button, not from the silent probe.
+        fn AXIsProcessTrusted() -> bool;
+
+        // Screen Recording (macOS 10.15+).
+        fn CGPreflightScreenCaptureAccess() -> bool;
+        fn CGRequestScreenCaptureAccess() -> bool;
+    }
+
+    pub fn probe() -> PermissionsReport {
+        let accessibility = probe_accessibility();
+        let screen_recording = probe_screen_recording();
+        let automation = probe_automation();
+        let full_disk = probe_full_disk();
+        PermissionsReport {
+            accessibility,
+            screen_recording,
+            automation,
+            full_disk,
+            platform_supported: true,
+        }
+    }
+
+    fn probe_accessibility() -> PermStatus {
+        if unsafe { AXIsProcessTrusted() } {
+            PermStatus::Granted
+        } else {
+            // We can't reliably distinguish NotDetermined from Denied
+            // through the AX API alone — both leave the process untrusted.
+            // The React wizard treats both the same (CTA is always
+            // "Open Settings → Accessibility").
+            PermStatus::NotDetermined
+        }
+    }
+
+    fn probe_screen_recording() -> PermStatus {
+        if unsafe { CGPreflightScreenCaptureAccess() } {
+            PermStatus::Granted
+        } else {
+            PermStatus::NotDetermined
+        }
+    }
+
+    /// Probe Automation by running an `osascript` no-op against Finder.
+    /// Per WS#5 decision Q2, Finder is the canonical probe target —
+    /// scripting it is intuitive consent ("pan-agent wants to control
+    /// Finder") and the runtime cookbook of WS#3 will mostly target
+    /// per-app scripting permissions granted on first-use anyway.
+    fn probe_automation() -> PermStatus {
+        let out = Command::new("/usr/bin/osascript")
+            .arg("-e")
+            .arg(r#"tell application "Finder" to return name of (path to home folder)"#)
+            .output();
+        match out {
+            Ok(o) if o.status.success() => PermStatus::Granted,
+            Ok(o) => {
+                let stderr = String::from_utf8_lossy(&o.stderr);
+                // -1743 = "Not authorized to send Apple events to Finder"
+                if stderr.contains("-1743") {
+                    PermStatus::Denied
+                } else {
+                    PermStatus::NotDetermined
+                }
+            }
+            Err(_) => PermStatus::Unknown,
+        }
+    }
+
+    /// Best-effort FDA probe. Reading Safari's bookmarks plist requires
+    /// Full Disk Access on macOS 10.14+. EPERM / "Operation not permitted"
+    /// → Denied; success → Granted; ENOENT (rare — user has never opened
+    /// Safari) → NotDetermined. Per WS#5 decision Q1, we only surface
+    /// FDA in the wizard lazily — the action journal triggers it when
+    /// it actually needs it.
+    fn probe_full_disk() -> PermStatus {
+        let home = match std::env::var_os("HOME") {
+            Some(h) => h,
+            None => return PermStatus::Unknown,
+        };
+        let path = std::path::Path::new(&home).join("Library/Safari/Bookmarks.plist");
+        match std::fs::metadata(&path) {
+            Ok(_) => PermStatus::Granted,
+            Err(e) => match e.kind() {
+                std::io::ErrorKind::NotFound => PermStatus::NotDetermined,
+                std::io::ErrorKind::PermissionDenied => PermStatus::Denied,
+                _ => PermStatus::Unknown,
+            },
+        }
+    }
+
+    pub fn request_screen_recording() {
+        // CGRequestScreenCaptureAccess triggers the system prompt the
+        // first time it's called per process. On subsequent calls (or
+        // when the user already responded) it's a cheap no-op returning
+        // the current grant.
+        let _ = unsafe { CGRequestScreenCaptureAccess() };
+    }
+
+    pub fn open_settings_pane(pane: &str) -> Result<(), String> {
+        // Map our short names to the macOS Settings deep-link scheme.
+        let url = match pane {
+            "Accessibility" => {
+                "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
+            }
+            "ScreenCapture" => {
+                "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture"
+            }
+            "Automation" => {
+                "x-apple.systempreferences:com.apple.preference.security?Privacy_Automation"
+            }
+            "AllFiles" | "FullDiskAccess" => {
+                "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles"
+            }
+            _ => return Err(format!("unknown settings pane: {pane}")),
+        };
+        Command::new("/usr/bin/open")
+            .arg(url)
+            .status()
+            .map_err(|e| e.to_string())?;
+        Ok(())
+    }
+
+    /// Suppress unused-import warnings for transitive CFDictionary/TCFType
+    /// imports that may be useful when we revisit the prompting AX
+    /// variant. Cheap to leave in; saves a follow-up Cargo.toml churn.
+    #[allow(dead_code)]
+    fn _suppress_unused() {
+        let _ = std::mem::size_of::<CFDictionary<i32, i32>>();
+        let _ = <core_foundation::string::CFString as TCFType>::type_id();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Non-macOS stub
+// ---------------------------------------------------------------------------
+
+#[cfg(not(target_os = "macos"))]
+mod imp {
+    use super::*;
+
+    pub fn probe() -> PermissionsReport {
+        PermissionsReport {
+            accessibility: PermStatus::Granted,
+            screen_recording: PermStatus::Granted,
+            automation: PermStatus::Granted,
+            full_disk: PermStatus::Granted,
+            platform_supported: false,
+        }
+    }
+
+    pub fn request_screen_recording() {}
+
+    pub fn open_settings_pane(_pane: &str) -> Result<(), String> {
+        Err("settings panes are macOS-only".into())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tauri command surface
+// ---------------------------------------------------------------------------
+
+/// Returns the current TCC grant state for every permission Pan-Agent
+/// cares about. The React wizard polls this every second while the
+/// Setup step is open; cheap to call repeatedly (each probe is an FFI
+/// or a bounded `osascript` exec).
+#[tauri::command]
+pub fn permissions_probe() -> PermissionsReport {
+    imp::probe()
+}
+
+/// Triggers the system Screen Recording prompt on macOS. Idempotent:
+/// once the user has granted (or permanently denied) the request, this
+/// becomes a cheap no-op. Returns immediately — the React side polls
+/// `permissions_probe` to detect the state change.
+#[tauri::command]
+pub fn permissions_request_screen_recording() {
+    imp::request_screen_recording();
+}
+
+/// Opens the matching pane in System Settings. `pane` is one of:
+/// `Accessibility | ScreenCapture | Automation | AllFiles`.
+#[tauri::command]
+pub fn permissions_open_settings(pane: String) -> Result<(), String> {
+    imp::open_settings_pane(&pane)
+}

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -48,6 +48,9 @@
     "externalBin": [
       "binaries/pan-agent"
     ],
+    "macOS": {
+      "minimumSystemVersion": "13.0"
+    },
     "windows": {
       "nsis": {
         "languages": ["English"],

--- a/desktop/src/assets/main.css
+++ b/desktop/src/assets/main.css
@@ -488,6 +488,212 @@ body {
   justify-content: flex-start;
 }
 
+/* ─── WS#5 macOS Permissions wizard step ─────────────────────────────────── */
+
+.setup-step--permissions {
+  width: 100%;
+  max-width: 620px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  margin-top: 16px;
+}
+
+.perm-loading,
+.perm-skipped {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 32px 16px;
+  color: var(--fg-muted);
+  font-size: 13px;
+}
+
+.perm-skipped {
+  color: var(--status-ok);
+}
+
+.perm-header h2 {
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--fg);
+  margin: 0 0 6px;
+}
+
+.perm-header p {
+  font-size: 13px;
+  color: var(--fg-muted);
+  margin: 0;
+  line-height: 1.5;
+}
+
+.perm-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.perm-row {
+  display: grid;
+  grid-template-columns: 32px 1fr auto;
+  gap: 14px;
+  align-items: start;
+  padding: 14px 16px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+}
+
+.perm-row--required {
+  border-color: var(--border-strong);
+}
+
+.perm-row-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+  color: var(--accent);
+}
+
+.perm-row-body {
+  min-width: 0;
+}
+
+.perm-row-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--fg);
+}
+
+.perm-row-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 1px 7px;
+  border-radius: 9999px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--fg-muted);
+}
+
+.perm-row-status--granted {
+  color: var(--status-ok);
+  border-color: var(--status-ok);
+  background: var(--status-ok-bg);
+}
+
+.perm-row-status--denied {
+  color: var(--status-err);
+  border-color: var(--status-err);
+  background: var(--status-err-bg);
+}
+
+.perm-row-status--pending {
+  color: var(--status-warn);
+  border-color: var(--status-warn);
+  background: var(--status-warn-bg);
+}
+
+.perm-row-desc {
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--fg-muted);
+  margin: 4px 0 0;
+}
+
+.perm-row-actions {
+  display: flex;
+  align-items: center;
+}
+
+.perm-row-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  background: var(--accent);
+  color: var(--accent-fg);
+  border: 1px solid var(--accent);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: filter var(--transition);
+}
+
+.perm-row-cta:hover:not(:disabled) {
+  filter: brightness(1.05);
+}
+
+.perm-row-cta:disabled {
+  opacity: 0.55;
+  cursor: progress;
+}
+
+.perm-row-cta:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.perm-blockers {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 10px 12px;
+  font-size: 12px;
+  border-radius: var(--radius-sm);
+  background: var(--status-warn-bg);
+  border: 1px solid var(--status-warn);
+  color: var(--status-warn);
+}
+
+.perm-footer {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 6px;
+}
+
+.setup-btn--primary {
+  padding: 10px 20px;
+  font-size: 14px;
+  font-weight: 600;
+  background: var(--accent);
+  color: var(--accent-fg);
+  border: 1px solid var(--accent);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: filter var(--transition);
+}
+
+.setup-btn--primary:hover:not(:disabled) {
+  filter: brightness(1.05);
+}
+
+.setup-btn--primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.perm-dev-stub {
+  font-size: 11px;
+  color: var(--fg-faint);
+  font-style: italic;
+}
+
 .setup-title {
   font-size: 22px;
   font-weight: 700;

--- a/desktop/src/lib/permissionGate.test.ts
+++ b/desktop/src/lib/permissionGate.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { canFinishWizard, ctaLabel, REQUIRED_PERMS } from "./permissionGate";
+import type { PermissionsReport } from "./tauri";
+
+// Pure-helper tests for the WS#5 wizard gate logic. No jsdom; matches
+// the existing desktop test convention (see budget-helpers.test.ts).
+
+function report(overrides: Partial<PermissionsReport> = {}): PermissionsReport {
+  return {
+    accessibility: "granted",
+    screen_recording: "granted",
+    automation: "granted",
+    full_disk: "granted",
+    platform_supported: true,
+    ...overrides,
+  };
+}
+
+describe("canFinishWizard", () => {
+  it("opens the gate when every required perm is granted", () => {
+    expect(canFinishWizard(report())).toBe(true);
+  });
+
+  it("blocks when accessibility is not granted", () => {
+    expect(canFinishWizard(report({ accessibility: "denied" }))).toBe(false);
+    expect(canFinishWizard(report({ accessibility: "not_determined" }))).toBe(
+      false,
+    );
+    expect(canFinishWizard(report({ accessibility: "unknown" }))).toBe(false);
+  });
+
+  it("blocks when screen recording is not granted", () => {
+    expect(canFinishWizard(report({ screen_recording: "denied" }))).toBe(false);
+  });
+
+  it("ignores automation status (optional / contextual)", () => {
+    expect(canFinishWizard(report({ automation: "denied" }))).toBe(true);
+  });
+
+  it("ignores full_disk status (lazy — requested per-action by the journal)", () => {
+    expect(canFinishWizard(report({ full_disk: "denied" }))).toBe(true);
+  });
+
+  it("always opens the gate on platforms without TCC", () => {
+    // Even with denied core perms, non-supported platforms (Win, Linux)
+    // see the wizard skipped entirely.
+    expect(
+      canFinishWizard(
+        report({
+          accessibility: "denied",
+          screen_recording: "denied",
+          platform_supported: false,
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("REQUIRED_PERMS only includes the two block-until-granted rows", () => {
+    expect([...REQUIRED_PERMS].sort()).toEqual([
+      "accessibility",
+      "screen_recording",
+    ]);
+  });
+});
+
+describe("ctaLabel", () => {
+  it("granted → static 'Granted'", () => {
+    expect(ctaLabel("granted", true)).toBe("Granted");
+    expect(ctaLabel("granted", false)).toBe("Granted");
+  });
+
+  it("denied flips to the Raycast 'previously denied' label", () => {
+    expect(ctaLabel("denied", true)).toBe("Open Settings (previously denied)");
+    expect(ctaLabel("denied", false)).toBe(
+      "Open Settings (previously denied)",
+    );
+  });
+
+  it("not_determined uses Grant Access when a programmatic prompt exists", () => {
+    expect(ctaLabel("not_determined", true)).toBe("Grant Access");
+  });
+
+  it("not_determined falls back to Open Settings when no programmatic prompt exists", () => {
+    expect(ctaLabel("not_determined", false)).toBe("Open Settings");
+  });
+
+  it("unknown is treated like not_determined", () => {
+    expect(ctaLabel("unknown", true)).toBe("Grant Access");
+    expect(ctaLabel("unknown", false)).toBe("Open Settings");
+  });
+});

--- a/desktop/src/lib/permissionGate.ts
+++ b/desktop/src/lib/permissionGate.ts
@@ -1,0 +1,61 @@
+/**
+ * Pure helpers for the WS#5 macOS permission wizard.
+ *
+ * The "block-until-granted" gate logic lives here so it can be unit-
+ * tested without spinning up the React tree (matches the existing
+ * desktop test style — pure helpers, no jsdom).
+ */
+import type { PermissionsReport, PermStatus } from "./tauri";
+
+/**
+ * Permissions Pan-Agent treats as required to ship the desktop bundle.
+ * Per WS#5 design (`docs/design/phase12.md` line 220+):
+ *   - Accessibility + Screen Recording are block-until-granted core.
+ *   - Automation is contextual (per-app prompt on first use).
+ *   - Full Disk Access is lazy (only requested when journal hits EPERM).
+ */
+export const REQUIRED_PERMS = ["accessibility", "screen_recording"] as const;
+export type RequiredPerm = (typeof REQUIRED_PERMS)[number];
+
+/**
+ * True when the user can advance past the wizard step. On non-macOS
+ * platforms (`platform_supported === false`) the gate is always open.
+ */
+export function canFinishWizard(report: PermissionsReport): boolean {
+  if (!report.platform_supported) return true;
+  return REQUIRED_PERMS.every(
+    (perm) => report[perm] === "granted",
+  );
+}
+
+/**
+ * Per-row CTA label. Per WS#5 plan, on Denied the label flips to
+ * "Open Settings (previously denied)" — Raycast pattern. On
+ * NotDetermined / Unknown the label is "Grant Access" (or "Open
+ * Settings" for permissions Apple doesn't expose a programmatic prompt
+ * for).
+ */
+export function ctaLabel(
+  status: PermStatus,
+  hasProgrammaticPrompt: boolean,
+): string {
+  if (status === "granted") return "Granted";
+  if (status === "denied") return "Open Settings (previously denied)";
+  if (hasProgrammaticPrompt) return "Grant Access";
+  return "Open Settings";
+}
+
+/**
+ * Lookup table mapping each permission to whether macOS exposes a
+ * programmatic prompt API for it. AX + Automation + FDA all require
+ * the user to flip a toggle in System Settings; only Screen Recording
+ * has a CGRequestScreenCaptureAccess() that pops the system prompt.
+ */
+export const HAS_PROGRAMMATIC_PROMPT: Record<keyof PermissionsReport, boolean> =
+  {
+    accessibility: false,
+    screen_recording: true,
+    automation: false,
+    full_disk: false,
+    platform_supported: false,
+  };

--- a/desktop/src/lib/tauri.ts
+++ b/desktop/src/lib/tauri.ts
@@ -1,0 +1,76 @@
+/**
+ * Typed bridge for Pan-Agent's Tauri `#[command]` invocations.
+ *
+ * Tauri's `invoke()` throws when it can't find the IPC channel — that
+ * happens whenever the desktop bundle is opened in plain Vite
+ * (`npm run dev:vite`) or a regular browser. The wrappers below detect
+ * the absence of the IPC and return a sensible "stub" response so the
+ * UI doesn't fall over during Vite-only development of the wizard.
+ *
+ * On the real Tauri shell, calls are forwarded straight through.
+ */
+import { invoke } from "@tauri-apps/api/core";
+
+export type PermStatus = "granted" | "denied" | "not_determined" | "unknown";
+
+export interface PermissionsReport {
+  accessibility: PermStatus;
+  screen_recording: PermStatus;
+  automation: PermStatus;
+  full_disk: PermStatus;
+  /** False on platforms without TCC (Linux, Windows). */
+  platform_supported: boolean;
+}
+
+export type SettingsPane =
+  | "Accessibility"
+  | "ScreenCapture"
+  | "Automation"
+  | "AllFiles"
+  | "FullDiskAccess";
+
+/**
+ * Detects whether the page is running inside the Tauri shell. Tauri
+ * injects `__TAURI_INTERNALS__` on the window before the React tree
+ * mounts, so the check is sync-safe at component-render time.
+ */
+export function isTauri(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    "__TAURI_INTERNALS__" in window
+  );
+}
+
+/**
+ * Probe the four TCC classes. Returns a stub "all granted, platform
+ * not supported" report when called outside the Tauri shell so the
+ * wizard step transparently skips itself in plain Vite dev.
+ */
+export async function probePermissions(): Promise<PermissionsReport> {
+  if (!isTauri()) {
+    return {
+      accessibility: "granted",
+      screen_recording: "granted",
+      automation: "granted",
+      full_disk: "granted",
+      platform_supported: false,
+    };
+  }
+  return invoke<PermissionsReport>("permissions_probe");
+}
+
+/**
+ * Trigger the system Screen Recording prompt. No-op in non-Tauri envs.
+ */
+export async function requestScreenRecording(): Promise<void> {
+  if (!isTauri()) return;
+  await invoke("permissions_request_screen_recording");
+}
+
+/**
+ * Open the matching pane in System Settings.
+ */
+export async function openSettingsPane(pane: SettingsPane): Promise<void> {
+  if (!isTauri()) return;
+  await invoke("permissions_open_settings", { pane });
+}

--- a/desktop/src/screens/Setup/Permissions.tsx
+++ b/desktop/src/screens/Setup/Permissions.tsx
@@ -1,0 +1,290 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  ShieldCheck,
+  AlertCircle,
+  ExternalLink,
+  Check,
+  Eye,
+  Mouse,
+  HardDrive,
+  Apple,
+} from "lucide-react";
+import {
+  isTauri,
+  openSettingsPane,
+  probePermissions,
+  requestScreenRecording,
+  type PermissionsReport,
+  type PermStatus,
+  type SettingsPane,
+} from "../../lib/tauri";
+import {
+  canFinishWizard,
+  ctaLabel,
+  HAS_PROGRAMMATIC_PROMPT,
+} from "../../lib/permissionGate";
+
+interface PermissionsProps {
+  onComplete: () => void;
+}
+
+interface RowConfig {
+  key: keyof PermissionsReport;
+  title: string;
+  description: string;
+  icon: React.ComponentType<{ size?: number; className?: string }>;
+  /** macOS Settings deep-link pane. Null for `platform_supported`. */
+  pane: SettingsPane | null;
+  /** Whether the row is required for Finish-button enablement. */
+  required: boolean;
+  /** Helper copy shown when the row is the only blocker. */
+  hint: string;
+}
+
+const ROWS: RowConfig[] = [
+  {
+    key: "accessibility",
+    title: "Accessibility",
+    description:
+      "Lets Pan-Agent read window titles and click UI elements when you ask it to drive other applications.",
+    icon: Mouse,
+    pane: "Accessibility",
+    required: true,
+    hint: "Required — open Settings → Privacy & Security → Accessibility and add Pan Desktop.",
+  },
+  {
+    key: "screen_recording",
+    title: "Screen Recording",
+    description:
+      "Lets the visual tools see what you see. Captures stay on your machine and are HMAC-redacted before being journaled.",
+    icon: Eye,
+    pane: "ScreenCapture",
+    required: true,
+    hint: "Required — click Grant Access to trigger the system prompt, or open Settings → Privacy & Security → Screen & System Audio Recording.",
+  },
+  {
+    key: "automation",
+    title: "Automation (optional)",
+    description:
+      "Lets Pan-Agent script other apps via Apple Events. Per-app prompts appear on first use — granting here is not required.",
+    icon: Apple,
+    pane: "Automation",
+    required: false,
+    hint: "macOS will request this per-app the first time the agent talks to a specific app.",
+  },
+  {
+    key: "full_disk",
+    title: "Full Disk Access (optional)",
+    description:
+      "Only needed if you ask the agent to write into TCC-protected folders (~/Library, ~/Desktop, ...). Pan-Agent will prompt lazily.",
+    icon: HardDrive,
+    pane: "FullDiskAccess",
+    required: false,
+    hint: "Optional — leave for later, the agent will surface a clear EPERM if it ever needs this.",
+  },
+];
+
+const STATUS_LABEL: Record<PermStatus, string> = {
+  granted: "Granted",
+  denied: "Denied",
+  not_determined: "Not requested",
+  unknown: "Unknown",
+};
+
+const STATUS_CLASS: Record<PermStatus, string> = {
+  granted: "perm-row-status--granted",
+  denied: "perm-row-status--denied",
+  not_determined: "perm-row-status--pending",
+  unknown: "perm-row-status--pending",
+};
+
+const POLL_INTERVAL_MS = 1000;
+
+export function Permissions({ onComplete }: PermissionsProps): React.JSX.Element {
+  const [report, setReport] = useState<PermissionsReport | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+  const finishRef = useRef<HTMLButtonElement>(null);
+
+  // 1 s poll while the wizard step is mounted. Cheap — every probe is
+  // a couple of FFI calls and a bounded osascript exec.
+  useEffect(() => {
+    let cancelled = false;
+    const tick = async () => {
+      try {
+        const r = await probePermissions();
+        if (cancelled) return;
+        setReport(r);
+        // If we're not on macOS the gate is open and the wizard step
+        // has nothing to render — auto-skip immediately.
+        if (!r.platform_supported) {
+          onComplete();
+        }
+      } catch (err) {
+        if (cancelled) return;
+        console.error("[Permissions] probe failed:", err);
+        // Treat probe failures as if the platform isn't supported so
+        // we don't strand the user behind a broken gate.
+        setReport({
+          accessibility: "unknown",
+          screen_recording: "unknown",
+          automation: "unknown",
+          full_disk: "unknown",
+          platform_supported: false,
+        });
+        onComplete();
+      }
+    };
+    void tick();
+    const id = setInterval(() => void tick(), POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [onComplete]);
+
+  // Pre-focus the Finish button as soon as it becomes enabled.
+  useEffect(() => {
+    if (report && canFinishWizard(report)) {
+      finishRef.current?.focus();
+    }
+  }, [report]);
+
+  if (!report) {
+    return (
+      <div className="setup-step setup-step--permissions">
+        <div className="perm-loading">Probing permissions…</div>
+      </div>
+    );
+  }
+
+  // Non-macOS callers see a brief "skipped" frame before onComplete fires.
+  if (!report.platform_supported) {
+    return (
+      <div className="setup-step setup-step--permissions">
+        <div className="perm-skipped">
+          <ShieldCheck size={20} />
+          <span>No macOS permissions to grant on this platform — continuing.</span>
+        </div>
+      </div>
+    );
+  }
+
+  async function handleCta(row: RowConfig) {
+    if (!report || report[row.key] === "granted") return;
+    setBusy(row.key);
+    try {
+      const status = report[row.key] as PermStatus;
+      if (
+        status === "not_determined" &&
+        HAS_PROGRAMMATIC_PROMPT[row.key] &&
+        row.key === "screen_recording"
+      ) {
+        await requestScreenRecording();
+      } else if (row.pane) {
+        await openSettingsPane(row.pane);
+      }
+    } catch (err) {
+      console.error(`[Permissions] CTA failed (${row.key}):`, err);
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  const ready = canFinishWizard(report);
+  const blockers = ROWS.filter(
+    (r) => r.required && report[r.key] !== "granted",
+  );
+
+  return (
+    <div className="setup-step setup-step--permissions">
+      <div className="perm-header">
+        <h2>System permissions</h2>
+        <p>
+          Pan-Agent needs a few macOS permissions to drive other apps and see
+          your screen. Setup polls every second — flip a toggle in System
+          Settings and this screen will update.
+        </p>
+      </div>
+
+      <div className="perm-rows" role="list">
+        {ROWS.map((row) => {
+          const status = report[row.key] as PermStatus;
+          const Icon = row.icon;
+          return (
+            <div
+              key={row.key}
+              className={`perm-row${row.required ? " perm-row--required" : ""}`}
+              role="listitem"
+            >
+              <div className="perm-row-icon">
+                <Icon size={18} />
+              </div>
+              <div className="perm-row-body">
+                <div className="perm-row-title">
+                  {row.title}
+                  <span
+                    className={`perm-row-status ${STATUS_CLASS[status]}`}
+                    aria-label={`Status: ${STATUS_LABEL[status]}`}
+                  >
+                    {status === "granted" ? (
+                      <Check size={11} aria-hidden="true" />
+                    ) : status === "denied" ? (
+                      <AlertCircle size={11} aria-hidden="true" />
+                    ) : null}
+                    {STATUS_LABEL[status]}
+                  </span>
+                </div>
+                <p className="perm-row-desc">{row.description}</p>
+              </div>
+              <div className="perm-row-actions">
+                {status !== "granted" && (
+                  <button
+                    type="button"
+                    className="perm-row-cta"
+                    onClick={() => handleCta(row)}
+                    disabled={busy === row.key}
+                  >
+                    {busy === row.key ? "…" : ctaLabel(status, HAS_PROGRAMMATIC_PROMPT[row.key])}
+                    <ExternalLink size={11} aria-hidden="true" />
+                  </button>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {!ready && blockers.length > 0 && (
+        <div className="perm-blockers" role="status" aria-live="polite">
+          <AlertCircle size={14} />
+          <div>
+            <strong>Waiting on:</strong>{" "}
+            {blockers.map((b, i) => (
+              <span key={b.key}>
+                {b.title}
+                {i < blockers.length - 1 ? ", " : ""}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className="perm-footer">
+        <button
+          ref={finishRef}
+          type="button"
+          className="setup-btn setup-btn--primary"
+          disabled={!ready}
+          onClick={onComplete}
+        >
+          {ready ? "Finish" : "Waiting for permissions…"}
+        </button>
+        {!isTauri() && (
+          <span className="perm-dev-stub">
+            (Vite-only dev — Tauri shell not detected, wizard will auto-skip)
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/screens/Setup/Setup.tsx
+++ b/desktop/src/screens/Setup/Setup.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { fetchJSON } from "../../api";
 import { PROVIDERS, LOCAL_PRESETS } from "../../constants";
 import icon from "../../assets/icon.png";
+import { Permissions } from "./Permissions";
 
 type SetupProvider = (typeof PROVIDERS.setup)[number];
 
@@ -9,7 +10,10 @@ interface SetupProps {
   onComplete: () => void;
 }
 
+type SetupStep = "provider" | "permissions";
+
 export default function Setup({ onComplete }: SetupProps) {
+  const [step, setStep] = useState<SetupStep>("provider");
   const [provider, setProvider] = useState<SetupProvider | null>(null);
   const [apiKey, setApiKey] = useState("");
   const [keyVisible, setKeyVisible] = useState(false);
@@ -61,7 +65,10 @@ export default function Setup({ onComplete }: SetupProps) {
         // Sync failure is non-fatal
       });
 
-      onComplete();
+      // Provider configured. Hand off to the WS#5 permissions wizard;
+      // it auto-skips on non-macOS and on Vite-only dev (no Tauri shell).
+      setSyncing(false);
+      setStep("permissions");
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       if (msg.includes("401") || msg.includes("403")) {
@@ -91,6 +98,21 @@ export default function Setup({ onComplete }: SetupProps) {
   const canSubmit =
     provider &&
     (!provider.needsKey || apiKey.trim() || provider.id === "custom-openai");
+
+  if (step === "permissions") {
+    return (
+      <div className="setup-screen">
+        <img
+          src={icon}
+          width={64}
+          height={64}
+          alt=""
+          style={{ borderRadius: "var(--radius-md)" }}
+        />
+        <Permissions onComplete={onComplete} />
+      </div>
+    );
+  }
 
   return (
     <div className="setup-screen">


### PR DESCRIPTION
## Summary

Closes the **v0.5.0 ship-gate** — Pan-Agent now walks new macOS users through granting the Apple TCC permissions its tools depend on before letting them past first-run Setup. Block-until-granted on Accessibility + Screen Recording; Automation and Full Disk Access are surfaced informationally (Q1+Q2 defaults).

Cross-platform safe: non-macOS targets get a stub probe returning `platform_supported: false` so the wizard step auto-skips. Tauri-shell detection (`__TAURI_INTERNALS__` on `window`) makes the same component run cleanly in plain `npm run dev:vite` without an IPC channel.

## Workstream context

| Decision (drafted Apr 25) | Outcome |
|---|---|
| **Q1** FDA proactive vs lazy | **Lazy** — only requested when the action journal hits EPERM. Wizard surfaces it as informational ("optional"). |
| **Q2** Automation probe target | **Finder**, not System Events — intuitive consent grant, matches WS#3 cookbook expectations. |
| **Q3** MDM banner placement | **Deferred** — `profiles -P` detection inside the wizard step is straightforward but adds another shell-out; saved for a follow-up. |
| **Q4** `security-framework` crate | **Deferred to WS#1 keyring work** — unused for WS#5 (it's a Keychain wrapper, not TCC). |
| **Q5** `objc2` vs hand-rolled `extern "C"` | **Hand-rolled extern "C"** + core-foundation — the probe surface is 3 C-ABI calls + osascript shell-out, objc2's proc-macro graph is overkill. |

## What landed

### Rust — `desktop/src-tauri/src/permissions.rs` (new module)

Four probes, all using **public TCC APIs only** (no `TCC.db` queries — SIP-protected since macOS 14, per Phase 12 design decision I5):

| Permission | Probe |
|---|---|
| Accessibility | `AXIsProcessTrusted()` (extern C) |
| Screen Recording | `CGPreflightScreenCaptureAccess()` (core-graphics) |
| Automation | `osascript` no-op against Finder + `-1743` error matching |
| Full Disk Access | `fs::metadata("~/Library/Safari/Bookmarks.plist")` heuristic |

Three new Tauri commands wired into the `invoke_handler`:
```
permissions_probe                       -> PermissionsReport
permissions_request_screen_recording    -> ()
permissions_open_settings(pane)         -> Result<(), String>
```

`open_settings_pane` shells `/usr/bin/open` with the `x-apple.systempreferences:` deep-link scheme (Accessibility, ScreenCapture, Automation, AllFiles).

### Cargo deps (macOS-only via `[target.'cfg(target_os = "macos")'.dependencies]`)

- `core-graphics = "0.24"` — `CGPreflight/RequestScreenCaptureAccess`
- `core-foundation = "0.10"` — CFString / CFDictionary types

### Tauri config

- `bundle.macOS.minimumSystemVersion = "13.0"`
- New `desktop/src-tauri/Info.plist` with user-focused usage descriptions for Apple Events, Screen Capture, Accessibility, and System Administration (App Store reviewers reject boilerplate).

### React — three new files in `desktop/src/lib/` and `desktop/src/screens/Setup/`

- **`lib/tauri.ts`** — typed bridge wrapping `@tauri-apps/api/core` `invoke()` with `isTauri()` detection and a sensible stub when the IPC channel isn't reachable.
- **`lib/permissionGate.ts` + `.test.ts`** — pure gate logic (`canFinishWizard`, `ctaLabel`) covered by **12 new Vitest cases**. Raycast "Open Settings (previously denied)" label flip on Denied; programmatic-prompt-aware CTA selection (only Screen Recording has a programmatic prompt API, the rest open System Settings panes).
- **`screens/Setup/Permissions.tsx`** — wizard step. 1 s `setInterval` polling, block-until-granted gate, oklch status badges, blocker summary, auto-focus on Finish when ready, auto-skip on non-macOS / non-Tauri.

`Setup.tsx` becomes a 2-step flow: **provider config → permissions**. The existing `onComplete` callback now fires after permissions land (or immediately on Linux/Windows).

## Verification

| Check | Result |
|---|---|
| `cargo build` (193 crates) | ✅ clean on `aarch64-apple-darwin` |
| `tsc --noEmit` (desktop) | ✅ clean |
| `vitest run` | ✅ **70 passed / 0 failed** (5 test files, +12 new gate tests) |
| `go build ./...` | ✅ clean (no backend changes) |
| Vite dev server | ✅ serves both new modules; bundle confirmed via module fetch |
| `verify-api.sh` | ✅ 64 routes, 20 documented, 44 exempt (no API changes) |

## Test plan

- [ ] `cargo build` on Linux + Windows runners (cfg gates compile cleanly with stub impl)
- [ ] Manual on a clean macOS profile: open Pan Desktop, configure provider → permission wizard appears with all rows pending → click Grant Access on Screen Recording → system prompt → grant → row flips green within 2 s; click Open Settings on Accessibility → Settings opens to Privacy & Security → Accessibility pane → toggle Pan Desktop → row flips green within 2 s; Finish button enables; click → app proceeds
- [ ] Deny Accessibility, click Open Settings → label reads "Open Settings (previously denied)" (Raycast pattern)
- [ ] On Linux + Windows: wizard step auto-skips (platform_supported = false), Setup completes with one Continue click
- [ ] On `npm run dev:vite` (no Tauri shell): same auto-skip path; "(Vite-only dev — Tauri shell not detected)" caption visible

## What's still deferred

- **MDM unsupported banner** (D10 / Q3) — `profiles -P` detection inside the wizard with a "proceed at your own risk" checkbox. Plumbing is straightforward, saved for a follow-up to keep this PR scoped.
- **Real macOS-runner integration test** — local `cargo build` covers the FFI link, but actually exercising the four probes against a fresh TCC database needs a CI runner with a clean `~/Library/Application Support/com.apple.TCC` snapshot. The Rust path can be mocked behind an extracted trait if we want CI coverage of the gate logic separately from the Apple SDK.

After this lands, **v0.5.0 frontend is complete** — the only open Phase 12 frontend item is the 202-flow approval polling polish on the History undo flow (currently relies on the 5 s auto-refresh; nice-to-have).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)