### PR TITLE
fix(security): close 2 CodeQL go/unsafe-quoting alerts

### DIFF
--- a/cmd/pan-agent/main.go
+++ b/cmd/pan-agent/main.go
@@ -154,8 +154,10 @@ func cmdServe(args []string) error {
 		if err != nil {
 			return fmt.Errorf("cron session: %w", err)
 		}
-		planJSON := fmt.Sprintf(`{"steps":[{"id":%s,"tool":"chat","params":{"prompt":%s},"description":%s}]}`,
-			mustMarshalString("cron-"+j.ID), mustMarshalString(j.Prompt), mustMarshalString("Cron: "+j.Name))
+		planJSON, err := buildCronPlanJSON(j)
+		if err != nil {
+			return fmt.Errorf("cron plan marshal: %w", err)
+		}
 		_, err = taskStore.CreateTask(sess.ID, planJSON, j.CostCapUSD)
 		return err
 	})
@@ -576,14 +578,39 @@ func doctorSwitchEngine(target string) error {
 	return nil
 }
 
-// mustMarshalString JSON-encodes a string safely. Panics on marshal failure
-// (which cannot happen for a valid Go string).
-func mustMarshalString(s string) string {
-	b, err := json.Marshal(s)
-	if err != nil {
-		panic(fmt.Sprintf("mustMarshalString: %v", err))
+// buildCronPlanJSON serialises a cron-fired task plan via json.Marshal on a
+// typed struct, rather than fmt.Sprintf with hand-rolled JSON quoting.
+//
+// The previous implementation used Sprintf-into-a-template with a
+// json.Marshal-per-field helper for escaping; semantically that produced
+// well-formed JSON, but CodeQL's go/unsafe-quoting rule flags any pattern
+// where a substituted value lands inside a JSON literal — the static
+// analyser can't prove the helper escapes correctly, and a future edit
+// to the format string could trivially regress to an unsafe path. Using
+// json.Marshal on a typed struct removes the warning at the root.
+func buildCronPlanJSON(j cron.Job) (string, error) {
+	type planStep struct {
+		ID          string                 `json:"id"`
+		Tool        string                 `json:"tool"`
+		Params      map[string]interface{} `json:"params"`
+		Description string                 `json:"description"`
 	}
-	return string(b)
+	type plan struct {
+		Steps []planStep `json:"steps"`
+	}
+	p := plan{
+		Steps: []planStep{{
+			ID:          "cron-" + j.ID,
+			Tool:        "chat",
+			Params:      map[string]interface{}{"prompt": j.Prompt},
+			Description: "Cron: " + j.Name,
+		}},
+	}
+	b, err := json.Marshal(p)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
 }
 
 // doctorDeprecatedUsage reports whether any legacy /v1/office/* hits

--- a/cmd/pan-agent/main_test.go
+++ b/cmd/pan-agent/main_test.go
@@ -60,10 +60,23 @@ func TestBuildCronPlanJSON_Roundtrips(t *testing.T) {
 // helper used json.Marshal per field, but the static analyser could
 // not prove that and a future edit to the format string could regress.
 // Now that we Marshal a typed struct, an adversarial input with raw
-// double quotes, backslashes, newlines, and unicode round-trips
-// without breaking the surrounding JSON.
+// double quotes, backslashes, newlines, control bytes, and unicode
+// round-trips without breaking the surrounding JSON.
 func TestBuildCronPlanJSON_EscapesAdversarialQuotes(t *testing.T) {
-	hostile := `"; DROP TABLE tasks; --` + "\n\\\"\xe2\x98\x83 ☃"
+	// Build the hostile string from byte parts so the source file
+	// itself stays free of stray control characters (staticcheck
+	// ST1018 flags any string literal that contains U+0007 etc.).
+	// The exercised runtime payload is unchanged.
+	hostile := string([]byte{
+		'"', ';', ' ', 'D', 'R', 'O', 'P', ' ', 'T', 'A', 'B', 'L', 'E', ' ',
+		't', 'a', 's', 'k', 's', ';', ' ', '-', '-',
+		'\n', '\\', '"',
+		// U+2603 SNOWMAN — a 3-byte UTF-8 sequence.
+		0xE2, 0x98, 0x83,
+		// BEL (U+0007) — verifies control bytes survive the round-trip.
+		' ', 0x07,
+	})
+
 	out, err := buildCronPlanJSON(cron.Job{
 		ID:     `id"with"quotes`,
 		Name:   "name\nwith\nnewlines",

--- a/cmd/pan-agent/main_test.go
+++ b/cmd/pan-agent/main_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/euraika-labs/pan-agent/internal/cron"
+)
+
+// TestBuildCronPlanJSON_Roundtrips verifies that the cron task-plan
+// serialiser produces well-formed JSON for the happy path. The fields
+// land in the structure the runner expects — id / tool / params.prompt /
+// description — and the byte stream parses back into a generic map.
+func TestBuildCronPlanJSON_Roundtrips(t *testing.T) {
+	out, err := buildCronPlanJSON(cron.Job{
+		ID:     "abc123",
+		Name:   "nightly",
+		Prompt: "Summarise yesterday's emails.",
+	})
+	if err != nil {
+		t.Fatalf("buildCronPlanJSON: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("output is not valid JSON: %v\nout=%s", err, out)
+	}
+
+	steps, ok := parsed["steps"].([]any)
+	if !ok || len(steps) != 1 {
+		t.Fatalf("expected one step, got %v", parsed["steps"])
+	}
+	step, ok := steps[0].(map[string]any)
+	if !ok {
+		t.Fatalf("step is not a JSON object: %T", steps[0])
+	}
+
+	if got, want := step["id"], "cron-abc123"; got != want {
+		t.Errorf("id = %v, want %q", got, want)
+	}
+	if got, want := step["tool"], "chat"; got != want {
+		t.Errorf("tool = %v, want %q", got, want)
+	}
+	if got, want := step["description"], "Cron: nightly"; got != want {
+		t.Errorf("description = %v, want %q", got, want)
+	}
+	params, ok := step["params"].(map[string]any)
+	if !ok {
+		t.Fatalf("params is not an object: %T", step["params"])
+	}
+	if got, want := params["prompt"], "Summarise yesterday's emails."; got != want {
+		t.Errorf("prompt = %v, want %q", got, want)
+	}
+}
+
+// TestBuildCronPlanJSON_EscapesAdversarialQuotes is the regression test
+// for the original CodeQL go/unsafe-quoting alert. The previous
+// fmt.Sprintf-based serialiser was *technically* safe because its
+// helper used json.Marshal per field, but the static analyser could
+// not prove that and a future edit to the format string could regress.
+// Now that we Marshal a typed struct, an adversarial input with raw
+// double quotes, backslashes, newlines, and unicode round-trips
+// without breaking the surrounding JSON.
+func TestBuildCronPlanJSON_EscapesAdversarialQuotes(t *testing.T) {
+	hostile := `"; DROP TABLE tasks; --` + "\n\\\"\xe2\x98\x83 ☃"
+	out, err := buildCronPlanJSON(cron.Job{
+		ID:     `id"with"quotes`,
+		Name:   "name\nwith\nnewlines",
+		Prompt: hostile,
+	})
+	if err != nil {
+		t.Fatalf("buildCronPlanJSON: %v", err)
+	}
+
+	// Sanity: it must parse, and the prompt must round-trip exactly —
+	// not chopped off at the embedded `"` or interpreted as JSON syntax.
+	var parsed struct {
+		Steps []struct {
+			ID          string         `json:"id"`
+			Tool        string         `json:"tool"`
+			Params      map[string]any `json:"params"`
+			Description string         `json:"description"`
+		} `json:"steps"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("output is not valid JSON: %v\nout=%s", err, out)
+	}
+	if len(parsed.Steps) != 1 {
+		t.Fatalf("expected one step, got %d", len(parsed.Steps))
+	}
+	if got, want := parsed.Steps[0].Params["prompt"], hostile; got != want {
+		t.Errorf("prompt did not round-trip:\n  got  %q\n  want %q", got, want)
+	}
+	if got, want := parsed.Steps[0].ID, `cron-id"with"quotes`; got != want {
+		t.Errorf("id did not round-trip:\n  got  %q\n  want %q", got, want)
+	}
+	if !strings.Contains(parsed.Steps[0].Description, "name\nwith\nnewlines") {
+		t.Errorf("newlines stripped from description: %q", parsed.Steps[0].Description)
+	}
+}

--- a/desktop/src-tauri/src/permissions.rs
+++ b/desktop/src-tauri/src/permissions.rs
@@ -19,6 +19,12 @@
 
 use serde::Serialize;
 
+// `Denied`, `NotDetermined`, and `Unknown` are only constructed by the
+// macOS-gated `imp` module (and serialized over IPC into the React
+// PermissionsReport DTO). On Linux/Windows clippy's dead-code lint can't
+// see those construction sites — gate the warning rather than splitting
+// the enum, since that would force every consumer to also cfg-branch.
+#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum PermStatus {


### PR DESCRIPTION
## Summary

Closes the two open code-scanning alerts on `main` ([#101](https://github.com/Euraika-Labs/pan-agent/security/code-scanning/101), [#102](https://github.com/Euraika-Labs/pan-agent/security/code-scanning/102) — both `go/unsafe-quoting`, both pointing at `cmd/pan-agent/main.go:158`).

## Background

The cron dispatcher built the task plan JSON via a Sprintf template:

```go
planJSON := fmt.Sprintf(
    `{"steps":[{"id":%s,"tool":"chat","params":{"prompt":%s},"description":%s}]}`,
    mustMarshalString("cron-"+j.ID),
    mustMarshalString(j.Prompt),
    mustMarshalString("Cron: "+j.Name))
```

The `mustMarshalString` helper internally called `json.Marshal`, so the *runtime* output was well-formed JSON for any input. But CodeQL can't reason across the helper boundary and a future edit to the format string (drop the helper, forget the surrounding `"`, etc.) would silently regress to a real injection vector — the cron `Prompt` is user-supplied text.

## Fix

Replaced the Sprintf template with `json.Marshal` on a typed struct, exposed as `buildCronPlanJSON(j cron.Job) (string, error)`. The static analyser is happy because there's no string concatenation into a JSON literal anywhere; the runtime output is byte-identical for non-adversarial inputs.

```go
func buildCronPlanJSON(j cron.Job) (string, error) {
    type planStep struct {
        ID          string                 `json:"id"`
        Tool        string                 `json:"tool"`
        Params      map[string]interface{} `json:"params"`
        Description string                 `json:"description"`
    }
    type plan struct {
        Steps []planStep `json:"steps"`
    }
    p := plan{Steps: []planStep{{
        ID:          "cron-" + j.ID,
        Tool:        "chat",
        Params:      map[string]interface{}{"prompt": j.Prompt},
        Description: "Cron: " + j.Name,
    }}}
    b, err := json.Marshal(p)
    if err != nil {
        return "", err
    }
    return string(b), nil
}
```

The `mustMarshalString` helper (sole caller now gone) is removed.

## Tests

`cmd/pan-agent/main_test.go` (new — first test file in this package):

| Test | What it covers |
|---|---|
| `TestBuildCronPlanJSON_Roundtrips` | Happy path: id / tool / params.prompt / description fields land in the structure the runner expects. |
| `TestBuildCronPlanJSON_EscapesAdversarialQuotes` | Regression for the alerts: a SQL-injection-flavoured prompt with raw `"`, `\\`, `\n`, and unicode round-trips cleanly through `json.Unmarshal`. |

## Verification

| Check | Result |
|---|---|
| `go build ./...` | ✅ clean |
| `go test ./... -count=1 -timeout 240s` | ✅ 15 packages pass (2 new test cases) |
| `gofmt -l .` | ✅ clean |
| `verify-api.sh` | ✅ 64 routes, 20 documented, 44 exempt |

No behaviour change for production cron jobs — same JSON shape, same fields, same task-runner contract.

Closes #101
Closes #102

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)