### PR TITLE
chore(release): v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,132 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-04-26
+
+Phase 12 frontend round — every workstream's React/Tauri counterpart
+shipped, plus the v0.7.0 audit-lane substrate sealed ahead of Phase 13.
+WS#5 macOS permission wizard closes the v0.5.0 ship-gate.
+
+### Added
+- **Brand system** (`desktop/src/assets/`) — oklch-based `--brand-navy`
+  / `--brand-gold` / `--brand-cream` tokens replace flat-hex
+  `--bg-primary` / `--accent` / `--warning` / `--error` etc. Bricolage
+  Grotesque variable font, brand assets under
+  `desktop/src/assets/branding/`. Light + dark themes regenerated.
+- **WS#1 cost-pill UI**
+  ([#25](https://github.com/Euraika-Labs/pan-agent/pull/25)) —
+  focus-trapped `<BudgetExceededDialog>` at 100% of cap (`[Increase 2x]`,
+  `[Increase custom…]`, `[End session]`); `BudgetBanner` trimmed to the
+  80% amber warning. New `GET /v1/sessions/{id}/info` endpoint +
+  `getSession()` mount-seed so the cost pill survives navigation rather
+  than resetting to `$0/$0` until the next budget SSE event.
+- **WS#2 task-grouped History**
+  ([#26](https://github.com/Euraika-Labs/pan-agent/pull/26)) — flat
+  list rewritten as `<TaskGroup>` per `task_id` with header
+  (plan-derived name, status badge, total cost, duration, freshest
+  receipt timestamp, inline `<CostSparkline>`) plus REVERSIBLE /
+  AUDIT-ONLY sub-lanes. "Reverted at HH:MM" stamp replaces the Undo
+  button in place — never reorders post-revert. New
+  `<UndoConfirmDialog>` with kind-aware copy + redacted payload preview
+  gates the actual reversal call. Lazy fan-out of `getTask` +
+  `getTaskEvents` per unique receipt `taskId`.
+- **WS#5 macOS permission onboarding wizard**
+  ([#27](https://github.com/Euraika-Labs/pan-agent/pull/27)) — new
+  Tauri `permissions.rs` module with public-API-only TCC probes
+  (`AXIsProcessTrusted` for Accessibility, `CGPreflightScreenCaptureAccess`
+  for Screen Recording, `osascript` no-op against Finder for
+  Automation, `~/Library/Safari/Bookmarks.plist` heuristic for FDA).
+  Three new Tauri commands + new `Permissions.tsx` step in Setup with
+  1s polling, block-until-granted gate (Accessibility + Screen
+  Recording required; Automation + FDA optional/lazy), Raycast "Open
+  Settings (previously denied)" label flip. `Info.plist` ships with
+  user-focused usage descriptions for AX, Screen Capture, Apple
+  Events, and System Administration. Auto-skips on non-macOS and in
+  plain Vite dev (no Tauri shell).
+- **Approval polling on History undo**
+  ([#29](https://github.com/Euraika-Labs/pan-agent/pull/29)) — when
+  `undoRecovery` returns 202 with an `approvalId`, History starts a
+  per-receipt 2s poller against `GET /v1/approvals/{id}` so the
+  reverted-stamp lands within ~2s of human approval rather than
+  waiting on the 5s journal-list refresh. Pollers cleared on unmount;
+  rejected approvals reset the row's Undo button.
+- **MDM unsupported banner**
+  ([#29](https://github.com/Euraika-Labs/pan-agent/pull/29)) —
+  `permissions.rs` shells `profiles -P` and exposes `mdm_managed` on
+  the report. Wizard surfaces a red banner + "proceed at your own
+  risk" checkbox that gates Finish on MDM-managed hosts (D10 / Q3).
+- **`internal/saaslinks/`** — sealed Gmail / Stripe / Google Calendar
+  deep-link library
+  ([#29](https://github.com/Euraika-Labs/pan-agent/pull/29)). Pure
+  URL builders (`Gmail`, `Stripe`, `StripeWithAccount`, `GCal`) with
+  comprehensive ID-injection guards (regex-validated before
+  interpolation). New audit-only `SaaSAPIReverser` registered with the
+  recovery `Registry` so `KindSaaSAPI` receipts no longer hit
+  `ErrNoReverserRegistered` once Phase 13 SaaS tools land. 13 unit
+  tests including base64URL stdlib byte-for-byte parity.
+
+### Changed
+- **Recovery: query-param rename to `session_id`**
+  ([#25](https://github.com/Euraika-Labs/pan-agent/pull/25)) —
+  `GET /v1/recovery/list` read camelCase `sessionID` while every other
+  backend handler used snake_case. Any session-scoped recovery list
+  was silently returning all receipts unfiltered. Now consistent
+  across the codebase and OpenAPI spec.
+- **Recovery DTO: `SaaSDeepLink` split**
+  ([#25](https://github.com/Euraika-Labs/pan-agent/pull/25)) — the
+  single overloaded field carried three semantics (FS snapshot
+  subpath, browser manual-undo hint, future SaaS API URL). Replaced
+  with `SaaSURL` (public http(s), JSON-exposed as `saasUrl`,
+  omitempty, only set for `kind=saas_api`) + `ReverserHint`
+  (reverser-private, never serialized). Idempotent backfill migration
+  in `migrateActionReceiptsSaasSplit`; legacy `saas_deep_link` column
+  kept for downgrade safety.
+- **Brand-system token migration**
+  ([#25](https://github.com/Euraika-Labs/pan-agent/pull/25)) —
+  CostPill, BudgetBanner, History, Permissions wizard, and dialog
+  styles all switched off `--warning` / `--error` / `--bg-primary` to
+  oklch `--status-warn` / `--status-err` / `--surface` / `--bg`.
+  Killed two duplicate `--surface` declarations that were silently
+  shadowed in `:root` and `[data-theme="light"]`.
+- **Session-detail endpoint** — added
+  `GET /v1/sessions/{id}/info` returning the full Session record (the
+  existing `GET /v1/sessions/{id}` is a historical alias for the
+  message list and was kept for backward compatibility).
+
+### Fixed
+- **macOS 15+ build regression**
+  ([#25](https://github.com/Euraika-Labs/pan-agent/pull/25)) —
+  bumped `kbinani/screenshot` from `v0.0.0-20230812` to
+  `v0.0.0-20250624`. The pinned 2023 version called
+  `CGDisplayCreateImageForRect`, obsoleted by Apple in macOS 15. Five
+  packages (`cmd/pan-agent`, `gateway`, `taskrunner`, `tools`,
+  `tools/interact`) failed to compile under fresh CGo cache on
+  current Apple SDKs.
+- **History "Undo" was silently broken**
+  ([#25](https://github.com/Euraika-Labs/pan-agent/pull/25)) — the
+  desktop client's `undoRecovery()` sent no body, so every Undo click
+  400'd against the backend's required `{"confirm": true}` guard. Now
+  sends the body, throws on 4xx/5xx, returns a typed
+  `UndoResult { applied, newStatus, details, approvalId?, httpStatus }`.
+- **CodeQL: `go/unsafe-quoting`** in `cmd/pan-agent/main.go:158`
+  ([#28](https://github.com/Euraika-Labs/pan-agent/pull/28); closes
+  GitHub security alerts #101 + #102, both warning / critical
+  security severity) — cron-fired task plan was assembled via
+  `fmt.Sprintf` template into a JSON literal. Replaced with
+  `json.Marshal` on a typed struct via a new `buildCronPlanJSON`
+  helper. Adversarial-input regression test covers raw quotes /
+  backslashes / newlines / control bytes / unicode.
+
+### Deferred to Phase 13
+- ARIA-YAML accessibility layer + direct-API cookbook skills (WS#3
+  desktop side).
+- Standalone Tasks UI surface.
+- Gmail / Stripe / Google Calendar tool implementations that produce
+  `KindSaaSAPI` receipts (the `internal/saaslinks/` library and the
+  `SaaSAPIReverser` stub seal the contract ahead of those landing).
+- Slack / Notion / Jira deep-links (out of v0.6.0 scope per WS#2
+  audit-lane spec).
+
 ## [0.5.0] - 2026-04-24
 
 Phase 12 "Trust-First Desktop Automation" — Go backend implementation

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pan-desktop",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Pan Desktop — Tauri desktop app for Pan-Agent",
   "productName": "Pan Desktop",
   "author": "Euraika Labs",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -2243,7 +2243,7 @@ dependencies = [
 
 [[package]]
 name = "pan-desktop"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "core-foundation",
  "core-graphics 0.24.0",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pan-desktop"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 
 [dependencies]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Pan Desktop",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "identifier": "net.euraika.pandesktop",
   "build": {
     "frontendDist": "../dist",

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -9,7 +9,7 @@ package version
 
 // Version is the semantic version string (e.g. "0.4.0").
 // Overridden via -ldflags at build time.
-var Version = "0.5.0"
+var Version = "0.6.0"
 
 // Commit is the short Git commit hash at build time.
 // Overridden via -ldflags at build time.


### PR DESCRIPTION
## Summary

Pre-tag release bump for **v0.6.0**. All four source-of-truth version strings move 0.5.0 → 0.6.0 in a single commit, plus a comprehensive CHANGELOG entry summarising every PR that landed today.

Bumping all four together avoids the v0.5.0 fire-drill where release artifacts shipped as `Pan.Desktop_0.4.4_*` under the v0.5.0 tag and needed a follow-up bump commit (see `888a9ac`).

## Files changed (6)

| File | Change |
|---|---|
| `internal/version/version.go` | `var Version = "0.6.0"` |
| `desktop/package.json` | `"version": "0.6.0"` |
| `desktop/src-tauri/Cargo.toml` | `version = "0.6.0"` |
| `desktop/src-tauri/Cargo.lock` | auto-updated by `cargo check` |
| `desktop/src-tauri/tauri.conf.json` | `"version": "0.6.0"` |
| `CHANGELOG.md` | new `[0.6.0] - 2026-04-26` section |

## CHANGELOG highlights

The new section covers everything that landed in this Phase 12 frontend round:

- **Added**: brand system (oklch + Bricolage Grotesque) · WS#1 cost-pill UI (#25) · WS#2 task-grouped History (#26) · WS#5 macOS permission wizard (#27) · approval polling on undo + MDM banner + saaslinks library (#29)
- **Changed**: recovery query-param rename to `session_id` (#25) · `Receipt.SaaSDeepLink` split into `SaaSURL` + `ReverserHint` with idempotent migration (#25) · session-detail endpoint (`/info`) (#25)
- **Fixed**: macOS 15+ build regression — `kbinani/screenshot` upgrade (#25) · History "Undo" silently 400'd because the body was missing (#25) · CodeQL `go/unsafe-quoting` × 2 closed (#28)
- **Deferred to Phase 13**: ARIA-YAML cookbook (WS#3 frontend) · Tasks UI · actual Gmail/Stripe/GCal tools (saaslinks contract is sealed)

## Verification

| Check | Result |
|---|---|
| `tsc --noEmit` (desktop) | ✅ clean |
| `vitest run` | ✅ 73 passed / 0 failed |
| `go build ./...` | ✅ clean |
| `go test ./... -count=1 -timeout 120s` | ✅ 17 packages pass |
| `cargo build` (desktop/src-tauri) | ✅ clean |
| `gofmt -l .` | ✅ clean |
| `verify-api.sh` | ✅ 64/20/44 |

## Test plan

- [ ] CI green on this PR
- [ ] After merge: tag `v0.6.0` annotated against the merge commit on `main`, push tag → `release.yml` builds signed installers for Windows (NSIS/MSI), macOS (DMG, both arms + intel-via-rosetta), Linux (DEB / AppImage), publishes a GitHub Release with `latest.json` for the auto-updater.
- [ ] Smoke-test the latest release binaries on Windows + macOS-arm + Linux: app launches, Setup wizard runs (provider config → permissions on macOS), Chat sends a message against a configured provider.
- [ ] Confirm the `latest.json` updater flow works for an existing v0.5.0 install.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)