### PR TITLE
feat(tasks): WS#13.A polish — cost pill, sparkline, heartbeat, cancel confirm

### DIFF
--- a/desktop/src/assets/main.css
+++ b/desktop/src/assets/main.css
@@ -5574,6 +5574,169 @@ body {
   line-height: 1.6;
 }
 
+/* ─── Phase 13 WS#13.A polish: cost pill, heartbeat, sparkline ──────────── */
+
+.tasks-cost-pill {
+  display: inline-flex;
+  align-items: center;
+  font-size: 11px;
+  font-weight: 500;
+  padding: 1px 8px;
+  border-radius: 99px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--fg-muted);
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.6;
+}
+.tasks-cost-pill--ok {
+  background: var(--surface);
+  color: var(--fg-muted);
+}
+.tasks-cost-pill--warn {
+  background: var(--status-warn-bg);
+  color: var(--status-warn);
+  border-color: var(--status-warn);
+}
+.tasks-cost-pill--exceeded {
+  background: var(--status-err-bg);
+  color: var(--status-err);
+  border-color: var(--status-err);
+}
+
+.tasks-card-heartbeat,
+.tasks-card-duration {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  color: var(--fg-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.tasks-detail-cost {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 10px;
+  margin-bottom: 10px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--accent);
+}
+
+.tasks-detail-cost-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--fg-muted);
+  margin-right: auto;
+}
+
+.tasks-detail-cost-spark {
+  display: inline-flex;
+  align-items: center;
+  line-height: 0;
+}
+
+.tasks-detail-cost-total {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--fg);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ─── CancelConfirmDialog (Phase 13 WS#13.A) ─────────────────────────────── */
+
+@keyframes cancelDialogFadeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+@keyframes cancelDialogPopIn {
+  from { opacity: 0; transform: translateY(8px) scale(0.98); }
+  to   { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+.cancel-dialog-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  background: oklch(0 0 0 / 0.55);
+  animation: cancelDialogFadeIn 150ms ease-out both;
+}
+
+.cancel-dialog {
+  background: var(--surface);
+  color: var(--fg);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-lg);
+  padding: 22px 24px 20px;
+  width: 100%;
+  max-width: 460px;
+  box-shadow: 0 18px 40px oklch(0 0 0 / 0.45);
+  animation: cancelDialogPopIn 180ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.cancel-dialog-title {
+  font-size: 16px;
+  font-weight: 600;
+  margin: 0;
+  color: var(--fg);
+}
+
+.cancel-dialog-desc {
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--fg-muted);
+  margin: 0;
+}
+
+.cancel-dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.cancel-dialog-btn {
+  font-size: 13px;
+  font-weight: 500;
+  padding: 8px 14px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--fg);
+  cursor: pointer;
+  transition: background var(--transition), border-color var(--transition);
+}
+.cancel-dialog-btn:hover {
+  background: var(--surface);
+  filter: brightness(1.04);
+}
+.cancel-dialog-btn:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+.cancel-dialog-btn--primary {
+  background: var(--status-err);
+  border-color: var(--status-err);
+  color: var(--bg);
+  font-weight: 600;
+}
+.cancel-dialog-btn--primary:hover {
+  background: var(--status-err);
+  filter: brightness(1.06);
+}
+
 /* ─── Status badge ───────────────────────────────────────────────────────── */
 
 .tasks-status-badge {

--- a/desktop/src/components/tasks/CancelConfirmDialog.tsx
+++ b/desktop/src/components/tasks/CancelConfirmDialog.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useRef } from "react";
+import type { Task } from "../../api";
+
+interface CancelConfirmDialogProps {
+  task: Task | null;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * Focus-trapped modal asking the user to confirm cancelling a task.
+ * Mirrors the WS#2 `<UndoConfirmDialog>` pattern (Esc + backdrop close,
+ * auto-focus primary, aria-modal). Cancel is one-click on the row card
+ * today; the dialog gates against accidental clicks now that running
+ * tasks may have already produced reversible journal receipts.
+ */
+export function CancelConfirmDialog({
+  task,
+  onConfirm,
+  onCancel,
+}: CancelConfirmDialogProps): React.JSX.Element | null {
+  const primaryRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!task) return;
+    primaryRef.current?.focus();
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onCancel();
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [task, onCancel]);
+
+  if (!task) return null;
+
+  const shortId = task.id.slice(-8);
+
+  return (
+    <div
+      className="cancel-dialog-backdrop"
+      onClick={onCancel}
+      role="presentation"
+    >
+      <div
+        className="cancel-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="cancel-dialog-title"
+        aria-describedby="cancel-dialog-desc"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 id="cancel-dialog-title" className="cancel-dialog-title">
+          Cancel task-{shortId}?
+        </h2>
+        <p id="cancel-dialog-desc" className="cancel-dialog-desc">
+          The task will stop after the current step. Any actions it has
+          already taken stay in the journal — you can review or undo
+          individual receipts in the History screen, but cancellation
+          itself does not roll back state.
+        </p>
+        <div className="cancel-dialog-actions">
+          <button
+            ref={primaryRef}
+            type="button"
+            className="cancel-dialog-btn cancel-dialog-btn--primary"
+            onClick={onConfirm}
+          >
+            Cancel task
+          </button>
+          <button
+            type="button"
+            className="cancel-dialog-btn"
+            onClick={onCancel}
+          >
+            Keep running
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/screens/Tasks/Tasks.tsx
+++ b/desktop/src/screens/Tasks/Tasks.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef, useCallback, memo } from "react";
+import { useEffect, useState, useRef, useCallback, useMemo, memo } from "react";
 import {
   RefreshCw,
   ListChecks,
@@ -23,13 +23,26 @@ import {
   resumeTask,
   cancelTask,
 } from "../../api";
-import type { Task, TaskStatus, TaskEvent, TaskEventKind } from "../../api";
+import type { Task, TaskEvent, TaskEventKind } from "../../api";
+import {
+  costState,
+  formatCostLabel,
+  formatLastHeartbeat,
+  formatTaskDuration,
+  groupTasks,
+  hasActiveTask,
+  isTerminal,
+  truncate,
+} from "./tasksGrouping";
+import { summarizeTaskCost } from "../History/historyGrouping";
+import { CostSparkline } from "../../components/history/CostSparkline";
+import { CancelConfirmDialog } from "../../components/tasks/CancelConfirmDialog";
 
 interface TasksProps {
   profile: string;
 }
 
-// ─── Helpers ────────────────────────────────────────────────────────────────
+// ─── Local helpers ──────────────────────────────────────────────────────────
 
 function formatTime(ts: number): string {
   const date = new Date(ts * 1000);
@@ -43,59 +56,6 @@ function formatFullDate(ts: number): string {
     ", " +
     date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
   );
-}
-
-type DateGroup = "Today" | "Yesterday" | "Earlier";
-
-function getDateGroup(ts: number): DateGroup {
-  const date = new Date(ts * 1000);
-  const now = new Date();
-
-  const isToday =
-    date.getDate() === now.getDate() &&
-    date.getMonth() === now.getMonth() &&
-    date.getFullYear() === now.getFullYear();
-  if (isToday) return "Today";
-
-  const yesterday = new Date(now);
-  yesterday.setDate(yesterday.getDate() - 1);
-  const isYesterday =
-    date.getDate() === yesterday.getDate() &&
-    date.getMonth() === yesterday.getMonth() &&
-    date.getFullYear() === yesterday.getFullYear();
-  if (isYesterday) return "Yesterday";
-
-  return "Earlier";
-}
-
-function groupTasks(
-  tasks: Task[],
-): Array<{ label: DateGroup; tasks: Task[] }> {
-  const groups = new Map<DateGroup, Task[]>();
-  for (const t of tasks) {
-    const group = getDateGroup(t.created_at);
-    if (!groups.has(group)) groups.set(group, []);
-    groups.get(group)!.push(t);
-  }
-  const order: DateGroup[] = ["Today", "Yesterday", "Earlier"];
-  return order
-    .filter((label) => groups.has(label))
-    .map((label) => ({ label, tasks: groups.get(label)! }));
-}
-
-const TERMINAL_STATUSES: TaskStatus[] = ["succeeded", "failed", "cancelled"];
-
-function isTerminal(status: TaskStatus): boolean {
-  return TERMINAL_STATUSES.includes(status);
-}
-
-function hasActiveTask(tasks: Task[]): boolean {
-  return tasks.some((t) => t.status === "running" || t.status === "queued");
-}
-
-function truncate(s: string, n: number): string {
-  if (s.length <= n) return s;
-  return s.slice(0, n) + "…";
 }
 
 // ─── Event kind icon ─────────────────────────────────────────────────────────
@@ -191,6 +151,23 @@ const TaskCard = memo(function TaskCard({
   const shortId = task.id.slice(-8);
   const shortSession = task.session_id.slice(-8);
 
+  // Cost-used is derived from task_events (kind=cost) rather than a
+  // dedicated column on the tasks table — events arrive lazily on
+  // expand so the collapsed row shows cap-only, and the pill/sparkline
+  // populate once the detail drawer opens.
+  const costSummary = useMemo(
+    () => summarizeTaskCost(events),
+    [events],
+  );
+  const cap = task.cost_cap_usd;
+  const used = costSummary.totalCostUsd;
+  const pillState = costState(used, cap);
+  const showHeartbeat = !terminal;
+  const duration = formatTaskDuration(
+    task.created_at,
+    task.last_heartbeat_at,
+  );
+
   return (
     <div className={`tasks-card tasks-card--${task.status}`}>
       {/* Summary row — clicking expands/collapses */}
@@ -209,12 +186,31 @@ const TaskCard = memo(function TaskCard({
           <span className="tasks-card-time">
             {formatFullDate(task.created_at)}
           </span>
+          {showHeartbeat && (
+            <span
+              className="tasks-card-heartbeat"
+              title="Last heartbeat from the runner — stale heartbeats trip the zombie reaper"
+            >
+              <Heart size={11} aria-hidden="true" />
+              {formatLastHeartbeat(task.last_heartbeat_at)}
+            </span>
+          )}
+          {terminal && (
+            <span className="tasks-card-duration" title="Total task duration">
+              {duration}
+            </span>
+          )}
         </div>
 
         <div className="tasks-card-meta">
-          {task.cost_cap_usd > 0 && (
-            <span className="tasks-tag">
-              cap ${task.cost_cap_usd.toFixed(2)}
+          {cap > 0 && (
+            <span className={`tasks-cost-pill tasks-cost-pill--${pillState}`}>
+              {formatCostLabel(used, cap)}
+            </span>
+          )}
+          {cap === 0 && used > 0 && (
+            <span className="tasks-cost-pill tasks-cost-pill--ok">
+              {formatCostLabel(used, 0)}
             </span>
           )}
           <span className="tasks-tag">step {task.next_plan_step_index}</span>
@@ -225,6 +221,24 @@ const TaskCard = memo(function TaskCard({
       {/* Expanded detail panel */}
       {expanded && (
         <div className="tasks-detail">
+          {/* Cost-over-time sparkline (Phase 13 WS#13.A polish) */}
+          {costSummary.sparkline.length > 0 && (
+            <div className="tasks-detail-cost">
+              <span className="tasks-detail-cost-label">Cost over time</span>
+              <span className="tasks-detail-cost-spark">
+                <CostSparkline
+                  points={costSummary.sparkline}
+                  width={140}
+                  height={26}
+                  ariaLabel={`Cost over time, total ${formatCostLabel(used, cap)}`}
+                />
+              </span>
+              <span className="tasks-detail-cost-total">
+                {formatCostLabel(used, cap)}
+              </span>
+            </div>
+          )}
+
           {/* Action buttons */}
           <div className="tasks-detail-actions">
             {task.status === "running" && (
@@ -277,6 +291,12 @@ function Tasks({ profile: _profile }: TasksProps): React.JSX.Element {
   const [eventsMap, setEventsMap] = useState<
     Record<string, { loading: boolean; events: TaskEvent[] }>
   >({});
+  // Pending cancel target — non-null while the CancelConfirmDialog is
+  // open. Cancelling now requires explicit confirmation rather than a
+  // single-click on the row card, mirroring the History undo flow.
+  const [pendingCancelTask, setPendingCancelTask] = useState<Task | null>(
+    null,
+  );
   const autoRefreshTimer = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const loadTasks = useCallback(async (): Promise<void> => {
@@ -375,7 +395,7 @@ function Tasks({ profile: _profile }: TasksProps): React.JSX.Element {
     [loadTasks],
   );
 
-  const handleCancel = useCallback(
+  const performCancel = useCallback(
     async (taskId: string): Promise<void> => {
       try {
         await cancelTask(taskId);
@@ -385,6 +405,13 @@ function Tasks({ profile: _profile }: TasksProps): React.JSX.Element {
       }
     },
     [loadTasks],
+  );
+
+  const handleCancel = useCallback(
+    (task: Task): void => {
+      setPendingCancelTask(task);
+    },
+    [],
   );
 
   const grouped = groupTasks(tasks);
@@ -434,13 +461,24 @@ function Tasks({ profile: _profile }: TasksProps): React.JSX.Element {
                   onToggle={() => handleToggle(t.id)}
                   onPause={() => handlePause(t.id)}
                   onResume={() => handleResume(t.id)}
-                  onCancel={() => handleCancel(t.id)}
+                  onCancel={() => handleCancel(t)}
                 />
               ))}
             </div>
           ))}
         </div>
       )}
+
+      <CancelConfirmDialog
+        task={pendingCancelTask}
+        onConfirm={() => {
+          if (pendingCancelTask) {
+            void performCancel(pendingCancelTask.id);
+          }
+          setPendingCancelTask(null);
+        }}
+        onCancel={() => setPendingCancelTask(null)}
+      />
     </div>
   );
 }

--- a/desktop/src/screens/Tasks/tasksGrouping.test.ts
+++ b/desktop/src/screens/Tasks/tasksGrouping.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, it } from "vitest";
+import {
+  costState,
+  formatCostLabel,
+  formatLastHeartbeat,
+  formatTaskDuration,
+  getDateGroup,
+  groupTasks,
+  hasActiveTask,
+  isTerminal,
+  truncate,
+} from "./tasksGrouping";
+import type { Task, TaskStatus } from "../../api";
+
+// Pure-helper tests for the WS#13.A Tasks screen polish. Logic-only style
+// matches the existing layout.shortcuts / budget-helpers / historyGrouping
+// suites — no React Testing Library, no jsdom.
+
+function task(id: string, partial: Partial<Task> = {}): Task {
+  return {
+    id,
+    status: "queued",
+    session_id: "sess-1",
+    created_at: 1_700_000_000,
+    next_plan_step_index: 0,
+    token_budget_cap: 0,
+    cost_cap_usd: 0,
+    ...partial,
+  };
+}
+
+describe("isTerminal", () => {
+  it("succeeded / failed / cancelled are terminal", () => {
+    expect(isTerminal("succeeded")).toBe(true);
+    expect(isTerminal("failed")).toBe(true);
+    expect(isTerminal("cancelled")).toBe(true);
+  });
+
+  it("queued / running / paused / zombie are non-terminal", () => {
+    const states: TaskStatus[] = ["queued", "running", "paused", "zombie"];
+    for (const s of states) {
+      expect(isTerminal(s)).toBe(false);
+    }
+  });
+});
+
+describe("hasActiveTask", () => {
+  it("true when at least one task is queued or running", () => {
+    expect(hasActiveTask([task("a", { status: "running" })])).toBe(true);
+    expect(hasActiveTask([task("a", { status: "queued" })])).toBe(true);
+  });
+
+  it("false when only paused / zombie / terminal", () => {
+    expect(hasActiveTask([task("a", { status: "paused" })])).toBe(false);
+    expect(hasActiveTask([task("a", { status: "zombie" })])).toBe(false);
+    expect(hasActiveTask([task("a", { status: "succeeded" })])).toBe(false);
+    expect(hasActiveTask([])).toBe(false);
+  });
+
+  it("a single active task in a terminal-heavy list still triggers true", () => {
+    expect(
+      hasActiveTask([
+        task("a", { status: "succeeded" }),
+        task("b", { status: "running" }),
+        task("c", { status: "failed" }),
+      ]),
+    ).toBe(true);
+  });
+});
+
+describe("getDateGroup", () => {
+  // getDateGroup compares local-time year/month/day (so users see
+  // Today/Yesterday relative to their wall clock, not UTC). All
+  // fixtures use the local-time `new Date(y, m, d, ...)` constructor
+  // so the suite passes regardless of the runner's timezone.
+  const NOW_MS = new Date(2026, 3, 26, 12, 0, 0).getTime(); // 2026-04-26 12:00 local
+
+  it("returns Today for a same-day timestamp", () => {
+    const morning = Math.floor(new Date(2026, 3, 26, 9, 0, 0).getTime() / 1000);
+    expect(getDateGroup(morning, NOW_MS)).toBe("Today");
+  });
+
+  it("returns Yesterday for a yesterday timestamp", () => {
+    const yesterdayNoon = Math.floor(
+      new Date(2026, 3, 25, 12, 0, 0).getTime() / 1000,
+    );
+    expect(getDateGroup(yesterdayNoon, NOW_MS)).toBe("Yesterday");
+  });
+
+  it("returns Earlier for older timestamps", () => {
+    const lastWeek = Math.floor(
+      new Date(2026, 3, 19, 12, 0, 0).getTime() / 1000,
+    );
+    expect(getDateGroup(lastWeek, NOW_MS)).toBe("Earlier");
+  });
+
+  it("midnight crossing — 23:59 yesterday vs 00:01 today (local)", () => {
+    const yesterday2359 = Math.floor(
+      new Date(2026, 3, 25, 23, 59, 0).getTime() / 1000,
+    );
+    const today0001 = Math.floor(
+      new Date(2026, 3, 26, 0, 1, 0).getTime() / 1000,
+    );
+    expect(getDateGroup(yesterday2359, NOW_MS)).toBe("Yesterday");
+    expect(getDateGroup(today0001, NOW_MS)).toBe("Today");
+  });
+});
+
+describe("groupTasks", () => {
+  const NOW_MS = new Date(2026, 3, 26, 12, 0, 0).getTime();
+  const todayTs = Math.floor(new Date(2026, 3, 26, 11, 0, 0).getTime() / 1000);
+  const yesterdayTs = Math.floor(
+    new Date(2026, 3, 25, 12, 0, 0).getTime() / 1000,
+  );
+  const earlierTs = Math.floor(
+    new Date(2026, 3, 19, 12, 0, 0).getTime() / 1000,
+  );
+
+  it("buckets in canonical order Today → Yesterday → Earlier", () => {
+    const groups = groupTasks(
+      [
+        task("e", { created_at: earlierTs }),
+        task("y", { created_at: yesterdayTs }),
+        task("t", { created_at: todayTs }),
+      ],
+      NOW_MS,
+    );
+    expect(groups.map((g) => g.label)).toEqual(["Today", "Yesterday", "Earlier"]);
+  });
+
+  it("preserves task order within each bucket (caller-newest-first)", () => {
+    const groups = groupTasks(
+      [
+        task("t1", { created_at: todayTs }),
+        task("t2", { created_at: todayTs - 60 }),
+      ],
+      NOW_MS,
+    );
+    expect(groups[0].tasks.map((t) => t.id)).toEqual(["t1", "t2"]);
+  });
+
+  it("drops empty buckets rather than emitting empty headers", () => {
+    const groups = groupTasks(
+      [task("t", { created_at: todayTs })],
+      NOW_MS,
+    );
+    expect(groups).toHaveLength(1);
+    expect(groups[0].label).toBe("Today");
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(groupTasks([], NOW_MS)).toEqual([]);
+  });
+});
+
+describe("truncate", () => {
+  it("returns input unchanged when short enough", () => {
+    expect(truncate("hello", 10)).toBe("hello");
+  });
+
+  it("appends a Unicode ellipsis when over budget", () => {
+    expect(truncate("hello world", 5)).toBe("hello…");
+  });
+
+  it("respects a tight budget", () => {
+    expect(truncate("abcdef", 3)).toBe("abc…");
+  });
+});
+
+describe("formatTaskDuration", () => {
+  it("under a second renders as <1s", () => {
+    expect(formatTaskDuration(100, 100, 100)).toBe("<1s");
+  });
+
+  it("seconds-only when below 60s", () => {
+    expect(formatTaskDuration(100, 142, 142)).toBe("42s");
+  });
+
+  it("minutes only when seconds remainder is zero", () => {
+    expect(formatTaskDuration(0, 180, 180)).toBe("3m");
+  });
+
+  it("minutes+seconds when both non-zero", () => {
+    expect(formatTaskDuration(0, 64, 64)).toBe("1m 4s");
+  });
+
+  it("hours+minutes when above an hour", () => {
+    expect(formatTaskDuration(0, 8040, 8040)).toBe("2h 14m");
+  });
+
+  it("falls back to now when no heartbeat", () => {
+    expect(formatTaskDuration(100, null, 200)).toBe("1m 40s");
+    expect(formatTaskDuration(100, undefined, 200)).toBe("1m 40s");
+  });
+
+  it("never returns negative durations on clock skew", () => {
+    expect(formatTaskDuration(200, 100, 100)).toBe("<1s");
+  });
+});
+
+describe("formatLastHeartbeat", () => {
+  it("returns 'never' when heartbeat is null/undefined", () => {
+    expect(formatLastHeartbeat(null, 100)).toBe("never");
+    expect(formatLastHeartbeat(undefined, 100)).toBe("never");
+  });
+
+  it("renders 'just now' inside 5 seconds", () => {
+    expect(formatLastHeartbeat(98, 100)).toBe("just now");
+    expect(formatLastHeartbeat(100, 100)).toBe("just now");
+  });
+
+  it("seconds within a minute", () => {
+    expect(formatLastHeartbeat(70, 100)).toBe("30s ago");
+  });
+
+  it("minutes within an hour", () => {
+    expect(formatLastHeartbeat(0, 600)).toBe("10m ago");
+  });
+
+  it("hours within a day", () => {
+    expect(formatLastHeartbeat(0, 7200)).toBe("2h ago");
+  });
+
+  it("yesterday for ~1 day", () => {
+    expect(formatLastHeartbeat(0, 86400)).toBe("yesterday");
+  });
+
+  it("days for older heartbeats", () => {
+    expect(formatLastHeartbeat(0, 86400 * 5)).toBe("5d ago");
+  });
+
+  it("future timestamps don't crash", () => {
+    expect(formatLastHeartbeat(1000, 100)).toBe("in the future");
+  });
+});
+
+describe("costState", () => {
+  it("returns 'none' when no cap configured", () => {
+    expect(costState(0, 0)).toBe("none");
+    expect(costState(1, 0)).toBe("none");
+  });
+
+  it("returns 'ok' below 80% of cap", () => {
+    expect(costState(0, 1)).toBe("ok");
+    expect(costState(0.79, 1)).toBe("ok");
+  });
+
+  it("returns 'warn' from 80% up to 100%", () => {
+    expect(costState(0.8, 1)).toBe("warn");
+    expect(costState(0.99, 1)).toBe("warn");
+  });
+
+  it("returns 'exceeded' at or above 100%", () => {
+    expect(costState(1, 1)).toBe("exceeded");
+    expect(costState(2, 1)).toBe("exceeded");
+  });
+});
+
+describe("formatCostLabel", () => {
+  it("uncapped form when cap=0", () => {
+    expect(formatCostLabel(0.04, 0)).toBe("$0.04");
+  });
+
+  it("capped form when cap>0", () => {
+    expect(formatCostLabel(0.04, 1.5)).toBe("$0.04 / $1.50");
+  });
+
+  it("rounds to two decimals", () => {
+    expect(formatCostLabel(0.123, 0)).toBe("$0.12");
+    expect(formatCostLabel(0.005, 0)).toBe("$0.01");
+  });
+});

--- a/desktop/src/screens/Tasks/tasksGrouping.ts
+++ b/desktop/src/screens/Tasks/tasksGrouping.ts
@@ -1,0 +1,184 @@
+/**
+ * Pure helpers for the Tasks screen — extracted from Tasks.tsx so the
+ * grouping/status/duration math is unit-testable without spinning up
+ * the React tree (matches the existing pattern in
+ * `desktop/src/screens/History/historyGrouping.ts` introduced in v0.6.0).
+ *
+ * Phase 13 WS#13.A polish: surfaces a cost-vs-cap pill, last-heartbeat
+ * info, and a duration formatter on each task row. The cost-summary
+ * helper (`summarizeTaskCost`) lives in `historyGrouping` and is
+ * imported there — same task_events shape, same payload semantics.
+ */
+import type { Task, TaskStatus } from "../../api";
+
+/** Date bucket the row falls under in the list header. */
+export type DateGroup = "Today" | "Yesterday" | "Earlier";
+
+const TERMINAL_STATUSES: ReadonlyArray<TaskStatus> = [
+  "succeeded",
+  "failed",
+  "cancelled",
+];
+
+/**
+ * True when the task is in a terminal state. Pause/Resume/Cancel
+ * buttons are gated on this.
+ */
+export function isTerminal(status: TaskStatus): boolean {
+  return TERMINAL_STATUSES.includes(status);
+}
+
+/**
+ * True when at least one task in the list is actively making progress.
+ * Drives the 5 s auto-refresh: idle lists don't poll the backend.
+ *
+ * `running` and `queued` are the only states the runner advances on
+ * its own — `paused` waits for human input, `zombie` was already
+ * detected by the reaper, and the three terminal states are immutable.
+ */
+export function hasActiveTask(tasks: ReadonlyArray<Task>): boolean {
+  return tasks.some((t) => t.status === "running" || t.status === "queued");
+}
+
+/**
+ * Compute the "Today / Yesterday / Earlier" bucket for an epoch-second
+ * timestamp. `nowMs` is injectable so tests can pin a clock; default is
+ * `Date.now()` so callers don't need to thread one through.
+ */
+export function getDateGroup(tsSeconds: number, nowMs: number = Date.now()): DateGroup {
+  const date = new Date(tsSeconds * 1000);
+  const now = new Date(nowMs);
+
+  const sameDay = (a: Date, b: Date): boolean =>
+    a.getDate() === b.getDate() &&
+    a.getMonth() === b.getMonth() &&
+    a.getFullYear() === b.getFullYear();
+
+  if (sameDay(date, now)) return "Today";
+
+  const yesterday = new Date(now);
+  yesterday.setDate(yesterday.getDate() - 1);
+  if (sameDay(date, yesterday)) return "Yesterday";
+
+  return "Earlier";
+}
+
+/**
+ * Bucket a (newest-first) task list into ordered date groups.
+ * Empty buckets are dropped from the output rather than rendered as
+ * empty headers.
+ */
+export function groupTasks(
+  tasks: ReadonlyArray<Task>,
+  nowMs: number = Date.now(),
+): Array<{ label: DateGroup; tasks: Task[] }> {
+  const groups = new Map<DateGroup, Task[]>();
+  for (const t of tasks) {
+    const group = getDateGroup(t.created_at, nowMs);
+    const bucket = groups.get(group);
+    if (bucket) bucket.push(t);
+    else groups.set(group, [t]);
+  }
+  const order: DateGroup[] = ["Today", "Yesterday", "Earlier"];
+  return order
+    .filter((label) => groups.has(label))
+    .map((label) => ({ label, tasks: groups.get(label)! }));
+}
+
+/**
+ * Truncate a string with a Unicode-safe ellipsis. Mirrors the inline
+ * helper that Tasks.tsx used; extracted for reuse + testability.
+ */
+export function truncate(s: string, n: number): string {
+  if (s.length <= n) return s;
+  return s.slice(0, n) + "…";
+}
+
+/**
+ * Format the task duration as a compact human string.
+ * Inputs are epoch-second timestamps (matches the Task struct fields
+ * `created_at` and `last_heartbeat_at`); pass `null`/`undefined` for
+ * a never-beaten task and the duration runs from `created_at` to now.
+ *
+ *   "3s" | "12s" | "1m 4s" | "2h 14m"
+ *
+ * Mirrors `formatDurationShort` in historyGrouping; we keep a separate
+ * implementation here to avoid cross-screen imports for a 10-line fn.
+ */
+export function formatTaskDuration(
+  createdAtSeconds: number,
+  lastHeartbeatSeconds: number | null | undefined,
+  nowSeconds: number = Math.floor(Date.now() / 1000),
+): string {
+  const end = lastHeartbeatSeconds ?? nowSeconds;
+  const elapsed = Math.max(0, end - createdAtSeconds);
+  if (elapsed < 1) return "<1s";
+  if (elapsed < 60) return `${elapsed}s`;
+  const m = Math.floor(elapsed / 60);
+  const s = elapsed % 60;
+  if (m < 60) return s ? `${m}m ${s}s` : `${m}m`;
+  const h = Math.floor(m / 60);
+  const mr = m % 60;
+  return mr ? `${h}h ${mr}m` : `${h}h`;
+}
+
+/**
+ * Format the "last heartbeat" relative time for the row meta.
+ * Matches Slack/Linear-style relative timestamps so the row shows
+ * "2m ago" rather than a full ISO timestamp.
+ *
+ *   "just now" | "12s ago" | "3m ago" | "2h ago" | "yesterday" | "<formatted date>"
+ *
+ * Only meaningful for non-terminal tasks; terminal tasks should show
+ * the absolute ended-at timestamp instead.
+ */
+export function formatLastHeartbeat(
+  heartbeatSeconds: number | null | undefined,
+  nowSeconds: number = Math.floor(Date.now() / 1000),
+): string {
+  if (heartbeatSeconds == null) return "never";
+  const elapsed = nowSeconds - heartbeatSeconds;
+  if (elapsed < 0) return "in the future";
+  if (elapsed < 5) return "just now";
+  if (elapsed < 60) return `${elapsed}s ago`;
+  const m = Math.floor(elapsed / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  if (d === 1) return "yesterday";
+  return `${d}d ago`;
+}
+
+/**
+ * Cost-vs-cap state used by the cost pill.
+ *   - "none" — no cap configured (cost_cap_usd === 0)
+ *   - "ok" — under 80% of cap
+ *   - "warn" — 80–99% of cap
+ *   - "exceeded" — at or over 100% of cap
+ *
+ * Mirrors the `pillVariant` semantics from `desktop/src/components/budget-helpers.ts`
+ * but operates on the Task struct's `cost_cap_usd` (which doesn't yet
+ * have a sibling `cost_used_usd` on the Task DTO — we derive it from
+ * the task_events stream via `summarizeTaskCost`).
+ */
+export type CostState = "none" | "ok" | "warn" | "exceeded";
+
+export function costState(used: number, cap: number): CostState {
+  if (cap <= 0) return "none";
+  const ratio = used / cap;
+  if (ratio >= 1) return "exceeded";
+  if (ratio >= 0.8) return "warn";
+  return "ok";
+}
+
+/**
+ * Render the cost label shown in the pill. Cap=0 produces the
+ * un-capped form ("$0.04") so the row doesn't read like a 0-cap
+ * exhausted task.
+ */
+export function formatCostLabel(used: number, cap: number): string {
+  const u = used.toFixed(2);
+  if (cap <= 0) return `$${u}`;
+  return `$${u} / $${cap.toFixed(2)}`;
+}


### PR DESCRIPTION
## Summary

Phase 13 WS#13.A polish for the Tasks screen. The screen already shipped in v0.5.0 with status badges, date grouping, expandable detail, and pause/resume/cancel — this PR brings it up to the substrate's full feature set with a cost-vs-cap pill, an inline cost-over-time sparkline, last-heartbeat info, and a confirmation dialog gating the Cancel button.

Per `docs/design/phase13.md` WS#13.A · ships in v0.7.0.

## Visible changes

| Where | What |
|---|---|
| Every row | **Cost-vs-cap pill** colour-coded by ratio: muted base <80%, amber 80-99%, red ≥100%. Uncapped tasks with non-zero cost surface as a base pill. |
| Running/queued rows | **Last-heartbeat chip** ("12s ago", "3m ago", "yesterday") — telegraphs when the reaper is about to demote a task to zombie. |
| Terminal rows | **Duration chip** ("1m 4s", "2h 14m") replaces heartbeat on finished tasks. |
| Expanded drawer | **Cost-over-time sparkline** when `task_events` contain `kind=cost` entries. Reuses v0.6.0 `<CostSparkline>` from `desktop/src/components/history/`. |
| Cancel button | **`<CancelConfirmDialog>`** gates it. Mirrors the WS#2 `<UndoConfirmDialog>` pattern (Esc + backdrop close, auto-focus, aria-modal). |

## Refactor

Helpers extracted into `desktop/src/screens/Tasks/tasksGrouping.ts` (mirrors the v0.6.0 `historyGrouping.ts` pattern):

```
isTerminal(status)                                  → boolean
hasActiveTask(tasks)                                → boolean
getDateGroup(tsSeconds, nowMs?)                     → DateGroup
groupTasks(tasks, nowMs?)                           → grouped buckets
truncate(s, n)                                      → ellipsis
formatTaskDuration(createdAt, lastHeartbeat?, now?) → string
formatLastHeartbeat(heartbeat?, now?)               → relative string
costState(used, cap)                                → 'none'|'ok'|'warn'|'exceeded'
formatCostLabel(used, cap)                          → "$0.04 / $1.50"
```

`summarizeTaskCost` is imported from `historyGrouping` (same `task_events` shape, same payload semantics — single canonical implementation).

## Tests

**38 new Vitest cases** in `tasksGrouping.test.ts` covering every helper:

- `isTerminal` × all 7 `TaskStatus` values
- `hasActiveTask` single-active / mixed / empty
- `getDateGroup` local-time semantics + midnight crossing
- `groupTasks` ordering / preservation / dropped-empty-buckets
- `truncate` Unicode-safe ellipsis
- `formatTaskDuration` <1s / s / m+s / h+m / heartbeat-fallback / clock-skew
- `formatLastHeartbeat` null / 'just now' / s / m / h / yesterday / d / future
- `costState` none / ok / warn / exceeded boundaries
- `formatCostLabel` uncapped / capped / two-decimal rounding

Suite is now **111 PASS / 0 FAIL** across 6 test files (was 73).

## Verification — all green

| Check | Result |
|---|---|
| `tsc --noEmit` | ✅ |
| `vitest run` | ✅ **111 / 0** |
| `go build ./...` | ✅ |
| `golangci-lint run` | ✅ 0 issues |
| `cargo build` + `cargo clippy --all-targets -- -D warnings` | ✅ |

No backend changes. No API changes. No new schema.

## Test plan

- [ ] Trigger a task with a cost cap (e.g. `cost_cap_usd=1.0`); cost-pill colours correctly transition base → amber → red as `task_events` accumulate.
- [ ] Cost sparkline appears in the expanded drawer once events with `kind=cost` arrive; matches the running total in the header pill.
- [ ] Click Cancel → `<CancelConfirmDialog>` modal appears; Esc + backdrop close cancels the cancel; "Cancel task" actually calls `cancelTask`.
- [ ] Running task left idle for >60s shows heartbeat ageing ("just now" → "12s ago" → "1m ago").
- [ ] Terminal task shows duration in place of heartbeat.

## Phase 13 substrate state after this lands

```
WS#13.F deep-links           ✅ shipped (#33)
WS#13.A Tasks UI polish      ✅ this PR
WS#13.B RAG                  plan in claude-flow memory phase13-plan/ws-B/plan
WS#13.C Marketplace          plan in phase13-plan/ws-C/plan
WS#13.D Gmail tool           plan in phase13-plan/ws-D-gmail/plan
WS#13.E ARIA-YAML cookbook   plan in phase13-plan/ws-E/plan
WS#13.G prompt redaction     plan in phase13-plan/ws-G/plan
```

After this PR + #32 + #33 land, v0.7.0 is shippable.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)