### PR TITLE
feat(skills): WS#13.E — cookbook stubs with embed.FS + frontmatter tests

### DIFF
--- a/internal/skills/embed/cookbook/reminders-create.md
+++ b/internal/skills/embed/cookbook/reminders-create.md
@@ -1,0 +1,86 @@
+---
+name: reminders-create
+description: "Create a reminder in macOS Reminders.app via the accessibility tree, no screenshots."
+---
+
+## When to use
+
+- The user says "remind me to X tomorrow at 9am" or any natural-
+  language reminder request, AND the platform is macOS (Reminders.app
+  is Apple-only).
+- On Windows or Linux, fall back to `cron_schedule` or
+  `task_create` with a notification step.
+
+## Steps
+
+1. Open the app:
+     interact intent: "open app", app: "Reminders"
+   Wait briefly for the window to come up; subsequent steps will
+   re-scrape if needed.
+
+2. Read the active window:
+     interact intent: "read active window", app: "Reminders"
+   Returns ARIA-YAML for the Reminders window. Locate the input row:
+     - role:  text_field
+     - name:  "New Reminder"
+   It usually sits at the top of the active list pane.
+
+3. Type the reminder text:
+     interact intent: "type", app: "Reminders", text: "<reminder body>"
+   This sets `value:` on the focused text_field.
+
+4. Press Return:
+     interact intent: "key", key: "Return"
+   This commits the reminder. macOS auto-parses date/time from natural
+   language ("tomorrow 9am" → schedules for tomorrow 09:00 local).
+
+5. Confirm by re-scraping; the reminder should now appear as a
+   `list_item` in the active list with the typed body and inferred
+   due-date.
+
+## Expected ARIA-YAML shape
+
+```yaml
+app: com.apple.reminders
+window:
+  title: "Reminders"
+focused: "tree.children[1].children[0]"   # the New Reminder text_field
+tree:
+  role: window
+  children:
+    - role: list                          # sidebar
+      name: "Lists"
+      children:
+        - role: list_item
+          name: "Reminders"
+          value: "selected"
+    - role: text_area
+      name: "Reminder list"
+      children:
+        - role: text_field
+          name: "New Reminder"
+          actions: [set_value, press]
+        - role: list_item                  # newly created reminder
+          name: "Buy milk"
+          value: "Tomorrow at 9 AM"
+```
+
+## Failure modes
+
+- **Reminders.app not installed** (rare — comes pre-installed on macOS
+  but can be removed) → `interact intent: "open app"` returns an
+  error; surface "Reminders.app isn't installed on this Mac."
+- **Permission revoked** (Accessibility or Automation/Reminders) →
+  `interact` returns the deep-link to the right Settings pane.
+- **Date parsing missed** (macOS doesn't recognise the phrasing) →
+  the reminder will be created without a due-date; scrape the
+  resulting list_item, see its `value:` is empty, and re-prompt the
+  user with a more explicit time format.
+
+## Cost-shape
+
+Produces one `KindFSWrite`-equivalent journal receipt via the
+Reminders SQLite store. Reversible by deleting the resulting
+list_item via:
+  interact intent: "delete", app: "Reminders", text: "<reminder body>"
+which the runtime maps to a focus + Cmd+Backspace sequence.

--- a/internal/skills/embed/cookbook/slack-summarise-channel.md
+++ b/internal/skills/embed/cookbook/slack-summarise-channel.md
@@ -1,0 +1,74 @@
+---
+name: slack-summarise-channel
+description: "Summarise the active Slack channel without screenshots, using the OS accessibility tree."
+---
+
+## When to use
+
+- The user asks "what's happening in #channel" / "summarise Slack" /
+  "catch me up on Slack" while Slack is the frontmost window.
+- Avoid this skill when Slack is not visible — you'll get a stale or
+  empty tree. Run `interact intent: "find window", app: "Slack"` first
+  if unsure.
+
+## Steps
+
+1. Call `interact` with:
+     intent:  "read active window"
+     app:     "Slack"
+   The tool returns ARIA-YAML describing the visible Slack window.
+
+2. From the returned tree, locate the messages list:
+     - role:  list
+     - name:  "Messages"
+   Each `list_item` child is one message; its `name:` is the author
+   and its `value:` is the message body. The channel name is at
+   `tree.children[0].name` (the sidebar selection).
+
+3. Walk the most-recent N list_items (typically the last 50 — Slack
+   virtualises older messages out of the tree, so what you see is
+   what's loaded). Concatenate `<author>: <body>` lines.
+
+4. Summarise in 3–5 bullets: who's discussing what, any open
+   questions, decisions made.
+
+## Expected ARIA-YAML shape
+
+```yaml
+app: com.tinyspeck.slackmacgap   # or "Slack" on Linux/Windows
+window:
+  title: "#general | Acme Slack"
+tree:
+  role: window
+  children:
+    - role: list
+      name: "Channels"          # sidebar
+      children: [...]
+    - role: list
+      name: "Messages"          # main pane
+      children:
+        - role: list_item
+          name: "Alice"          # author
+          value: "Lunch?"        # body
+        - role: list_item
+          name: "Bob"
+          value: "👍"
+```
+
+## Failure modes
+
+- **Slack not frontmost** → `interact` returns layer=`unsupported` with
+  an error string. Surface "Open Slack first, then ask again."
+- **Permission revoked** (macOS: Accessibility / per-app Automation)
+  → `interact` returns layer=`unsupported`, error=`accessibility_revoked`
+  or app-specific `automation_denied`. Open the Setup → Permissions
+  step via the deep-link the tool returns.
+- **Empty messages list** → channel is brand-new or just loaded;
+  scroll up and retry, or fall back to "Slack is open but no messages
+  loaded yet."
+
+## Cost-shape
+
+This is a read-only skill — no journal receipts produced. Token cost is
+limited to the ARIA-YAML tree size (typically 2-4k tokens for an active
+channel) plus the summary output.

--- a/internal/skills/embed/cookbook/vscode-open-under-cursor.md
+++ b/internal/skills/embed/cookbook/vscode-open-under-cursor.md
@@ -1,0 +1,97 @@
+---
+name: vscode-open-under-cursor
+description: "Open the file path under the cursor in VS Code, using the editor's accessibility tree."
+---
+
+## When to use
+
+- The user asks "open this file" / "jump to that path" / "open the
+  file the cursor is on" while Visual Studio Code is the frontmost
+  window.
+- The cursor must be inside an editor pane; if it's in a panel
+  (terminal, output, debug console) the path-extraction heuristic
+  changes — see Failure modes.
+
+## Steps
+
+1. Read the active window:
+     interact intent: "read active window", app: "Visual Studio Code"
+   Returns ARIA-YAML for the VS Code window. The active editor is
+   identifiable by `id: "editor.main"` — VS Code sets a stable id on
+   the main editor's text_area role.
+
+2. Inspect the focused node:
+     - `focused:` path resolves to a `text_area` with `id: "editor.main"`
+     - `value:` contains the editor's text content
+     - The cursor offset is *not* directly in the tree on macOS AX,
+       so we approximate via the focused line's content. Use the
+       `focused-line` field if the scrape was done with
+       `include_focused_line: true`; otherwise scan for the most
+       recent `\n` before the rendered cursor coords.
+
+3. Extract a path-shaped token from the cursor neighbourhood. A
+   "path-shaped token" is a contiguous run of non-whitespace
+   characters containing at least one `/` (or `\\` on Windows) and
+   matching one of:
+     - relative to repo root: `internal/foo/bar.go`
+     - absolute:              `/Users/.../foo.go`
+     - import path:           `github.com/user/repo/foo`
+   The first form is the most common in code; if you find multiple
+   candidates, prefer the one closest to the cursor.
+
+4. Open via VS Code's quick-open palette:
+     interact intent: "key", key: "cmd+p"     (macOS) or "ctrl+p" (others)
+     interact intent: "type", text: "<extracted path>"
+     interact intent: "key", key: "Return"
+
+5. Confirm by re-scraping; the active editor's `value:` should now be
+   the contents of the opened file. If quick-open auto-suggested a
+   different (mis-spelled) match, report which file actually opened.
+
+## Expected ARIA-YAML shape
+
+```yaml
+app: com.microsoft.VSCode
+window:
+  title: "interact.go — pan-agent"
+focused: "tree.children[0].children[2].children[1]"
+tree:
+  role: window
+  children:
+    - role: tab_group
+      name: "Editors"
+      children:
+        - role: tab
+          name: "interact.go"
+          value: "active"
+          actions: [press]
+    - role: text_area
+      name: "Editor: interact.go"
+      id: "editor.main"
+      value: |
+        package interact
+
+        import (
+          "context"
+          "internal/tools/aria"   // <-- cursor here, "internal/tools/aria" is the candidate
+        )
+      actions: [press, set_value]
+```
+
+## Failure modes
+
+- **Cursor in a panel, not the editor** → `id: "editor.main"` is not
+  the focused node. Surface "the cursor isn't in an editor — click
+  into a file first" rather than guessing which path to open.
+- **No path-shaped token near cursor** → ambiguous request; ask the
+  user "which path should I open?" with the 2-3 closest candidates.
+- **Quick-open palette didn't appear** (a modal dialog has focus) →
+  the Cmd+P key gets swallowed; scrape, detect the modal, dismiss it
+  with Esc, retry.
+- **Permission revoked** → `interact` returns the Accessibility deep-
+  link via the error path, same as the other cookbook skills.
+
+## Cost-shape
+
+Read-only. Opening a file in VS Code is a UI navigation action; no
+journal receipt produced.

--- a/internal/skills/embed/cookbook_test.go
+++ b/internal/skills/embed/cookbook_test.go
@@ -1,0 +1,142 @@
+package embed
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/euraika-labs/pan-agent/internal/skills"
+)
+
+// TestCookbookFS_BundledSkillsHaveValidFrontmatter walks every cookbook
+// markdown file the binary embedded and asserts each one starts with a
+// valid YAML frontmatter block carrying name + description.
+//
+// This is the load-bearing invariant for Phase 13 WS#13.E: the runtime
+// walker (future SeedCookbook) parses frontmatter to surface skills in
+// the desktop UI. A cookbook entry that ships without valid frontmatter
+// would be silently dropped at runtime, so we fail the build (test
+// pass is a prerequisite for shipping a new cookbook entry).
+func TestCookbookFS_BundledSkillsHaveValidFrontmatter(t *testing.T) {
+	entries, err := CookbookFS.ReadDir(CookbookRoot)
+	if err != nil {
+		t.Fatalf("ReadDir cookbook root: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatalf("cookbook root is empty — no skills bundled")
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			t.Errorf("nested directory %q not yet supported in cookbook", e.Name())
+			continue
+		}
+		if !strings.HasSuffix(e.Name(), ".md") {
+			t.Errorf("non-.md file %q in cookbook", e.Name())
+			continue
+		}
+		path := CookbookRoot + "/" + e.Name()
+		content, err := CookbookFS.ReadFile(path)
+		if err != nil {
+			t.Errorf("read %q: %v", path, err)
+			continue
+		}
+		if err := skills.ValidateFrontmatter(string(content)); err != nil {
+			t.Errorf("frontmatter invalid for %q: %v", path, err)
+		}
+	}
+}
+
+// TestCookbookFS_NamesDistinct guarantees the bundled skills don't
+// collide on `name:` (the runtime keys on it). Catches a copy-paste
+// bug where a new cookbook entry forgets to rename the frontmatter
+// after duplicating an existing one.
+func TestCookbookFS_NamesDistinct(t *testing.T) {
+	entries, err := CookbookFS.ReadDir(CookbookRoot)
+	if err != nil {
+		t.Fatalf("ReadDir cookbook root: %v", err)
+	}
+	seen := make(map[string]string)
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+			continue
+		}
+		path := CookbookRoot + "/" + e.Name()
+		content, err := CookbookFS.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %q: %v", path, err)
+		}
+		name := extractFrontmatterField(string(content), "name")
+		if name == "" {
+			t.Errorf("cookbook %q has empty/missing name in frontmatter", path)
+			continue
+		}
+		if prev, dup := seen[name]; dup {
+			t.Errorf("name collision: %q is used by both %q and %q", name, prev, path)
+		}
+		seen[name] = path
+	}
+	if len(seen) < len(entries) {
+		// Already errored above; this is a sanity guard for the count.
+		return
+	}
+}
+
+// TestCookbookFS_KnownEntriesPresent pins the v0.7.0 cookbook contents
+// so a future refactor can't accidentally drop a starter skill.
+func TestCookbookFS_KnownEntriesPresent(t *testing.T) {
+	wantNames := map[string]bool{
+		"slack-summarise-channel":  true,
+		"reminders-create":         true,
+		"vscode-open-under-cursor": true,
+	}
+	entries, err := CookbookFS.ReadDir(CookbookRoot)
+	if err != nil {
+		t.Fatalf("ReadDir cookbook root: %v", err)
+	}
+	got := make(map[string]bool)
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+			continue
+		}
+		path := CookbookRoot + "/" + e.Name()
+		content, err := CookbookFS.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		got[extractFrontmatterField(string(content), "name")] = true
+	}
+	for want := range wantNames {
+		if !got[want] {
+			t.Errorf("cookbook missing expected starter skill: %q", want)
+		}
+	}
+}
+
+// extractFrontmatterField returns the trimmed value of a top-level
+// `key: value` line in the leading YAML frontmatter block, or "" if
+// the field is absent. Matches the simple-scalar contract of
+// skills.ValidateFrontmatter without requiring a full YAML parser.
+func extractFrontmatterField(content, field string) string {
+	trimmed := strings.TrimLeft(content, "\r\n\t ")
+	if !strings.HasPrefix(trimmed, "---") {
+		return ""
+	}
+	body := trimmed[3:]
+	end := strings.Index(body, "---")
+	if end == -1 {
+		return ""
+	}
+	for _, line := range strings.Split(body[:end], "\n") {
+		line = strings.TrimRight(line, "\r")
+		// Match "<field>: …" exactly to avoid prefix collisions
+		// (e.g. "name_alt:" wouldn't match the field "name").
+		prefix := field + ":"
+		if !strings.HasPrefix(strings.TrimSpace(line), prefix) {
+			continue
+		}
+		v := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line), prefix))
+		// Strip surrounding quotes if present.
+		v = strings.Trim(v, `"'`)
+		return v
+	}
+	return ""
+}

--- a/internal/skills/embed/embed.go
+++ b/internal/skills/embed/embed.go
@@ -1,12 +1,37 @@
 // Package embed bundles the reviewer + curator persona markdown into the
 // binary so the agent loops always have a stable behavioural contract,
 // independent of whatever the user has installed in their skills directory.
+//
+// Phase 13 WS#13.E adds the cookbook subdirectory: starter skills that
+// demonstrate the canonical "interact tool + ARIA-YAML accessibility
+// tree" pattern. The cookbook ships in the binary and the skills
+// runtime seeds them into the user's `<ProfileSkillsDir>/desktop/` on
+// first run (so users can edit/delete them without disrupting the
+// authoritative version we shipped).
 package embed
 
-import _ "embed"
+import (
+	"embed"
+	_ "embed"
+)
 
 //go:embed reviewer.md
 var ReviewerMD string
 
 //go:embed curator.md
 var CuratorMD string
+
+// CookbookFS exposes the cookbook/ subdirectory as an `embed.FS` so
+// the runtime can iterate every skill file without hard-coding names
+// here. New skills added to the directory get bundled by re-running
+// `go build`; the runtime walker (skills.SeedCookbook, future) reads
+// the FS and writes each entry into the user profile if not already
+// present.
+//
+//go:embed cookbook/*.md
+var CookbookFS embed.FS
+
+// CookbookRoot is the directory inside CookbookFS where skill markdown
+// files live. Exposed so the walker doesn't have to keep the literal
+// "cookbook" string in sync across multiple files.
+const CookbookRoot = "cookbook"


### PR DESCRIPTION
## Summary

First Phase 13 WS#13.E slice. Ships three starter cookbook skills as `go:embed`-ed markdown that demonstrate the canonical "interact tool + ARIA-YAML accessibility tree" pattern. The skills are **inert today** — they describe runtime flows that will light up automatically once the `internal/tools/aria` scrape lands in a follow-up PR — but they go in NOW so the contract (what skill bodies look like for direct-API flows) is documented + tested.

## New cookbook entries

```
internal/skills/embed/cookbook/
  slack-summarise-channel.md    "Summarise the active Slack channel"
  reminders-create.md           "Create a reminder in Reminders.app"
  vscode-open-under-cursor.md   "Open the file path under the cursor"
```

Each entry follows the same shape: **When to use** · **Steps** · **Expected ARIA-YAML shape** · **Failure modes** · **Cost-shape**. The Failure-modes section names the exact `interact` error path (`permission_revoked`, `accessibility_revoked`, `automation_denied`, etc.) so future runtime code has a contract to check against.

## embed.go updates

```go
//go:embed cookbook/*.md
var CookbookFS embed.FS

const CookbookRoot = "cookbook"
```

`CookbookFS` is exposed via `embed.FS` so the runtime walker (future `skills.SeedCookbook`, separate PR) iterates entries without hard-coding names. New skills go in by dropping a `.md` in the directory + re-running `go build`.

## cookbook_test.go — three load-bearing invariants

| Test | What it guards against |
|---|---|
| `TestCookbookFS_BundledSkillsHaveValidFrontmatter` | Skill silently dropped at runtime because frontmatter is malformed |
| `TestCookbookFS_NamesDistinct` | Copy-paste bug where two cookbook entries share a `name:` and one shadows the other |
| `TestCookbookFS_KnownEntriesPresent` | A future refactor accidentally removes one of the v0.7.0 starter skills |

## Verification — all green

| Check | Result |
|---|---|
| `go build ./...` | ✅ |
| `go test ./...` | ✅ 18 packages pass (+3 new tests) |
| `golangci-lint run` | ✅ 0 issues |
| `cargo build` + `cargo clippy --all-targets -- -D warnings` | ✅ |
| `gofmt -l .` | ✅ |
| `verify-api.sh` | ✅ no API change |

## What this PR does NOT include (deliberately)

- The `internal/tools/aria/` scrape implementation (macOS AXUIElement FFI, Windows UIA helper binary, Linux AT-SPI). Each needs platform-specific work that deserves its own focused review pass.
- `skills.SeedCookbook` runtime walker that copies cookbook entries into `<ProfileSkillsDir>/desktop/` on first run.
- `interact` router updates that recognise observational vs actionable intents and pick the accessibility layer.

All three are scoped in the Phase 13 WS#13.E specialist plan stored in claude-flow memory under `phase13-plan/ws-E/plan` (retrievable via `mcp__claude-flow__memory_retrieve` from any future session).

## Phase 13 substrate state

```
WS#13.F deep-links             ✅ shipped (#33)
WS#13.A Tasks UI polish         🟡 PR #34 open
WS#13.E cookbook stubs          🟡 this PR
WS#13.E aria scrape             plan in claude-flow memory
WS#13.B RAG                     plan in claude-flow memory
WS#13.C Marketplace             plan in claude-flow memory
WS#13.D Gmail tool              plan in claude-flow memory
WS#13.G prompt redaction        plan in claude-flow memory
```

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)