### PR TITLE
refactor(secret): extract applyClassifier + protectNegatives helpers (WS#13.G prep)

### DIFF
--- a/internal/secret/redaction.go
+++ b/internal/secret/redaction.go
@@ -98,6 +98,105 @@ func RedactBytes(b []byte) []byte {
 	return []byte(Redact(string(b)))
 }
 
+// applyClassifier rewrites text by running classifier c's regex over it
+// and invoking emit() for each match that passes the length-bound +
+// negative-regex predicates. emit() returns the replacement string for
+// the matched span; for classifiers with a capture group the returned
+// token replaces only the captured group, leaving the surrounding
+// context (e.g. the "Bearer " prefix) intact.
+//
+// Extracted from redactInternal in Phase 13 WS#13.G prep so the future
+// LLM-redaction pipeline can reuse the exact same match-finding +
+// replacement contract while plugging in a different emit (per-
+// conversation reversible counter tokens instead of HMAC tokens).
+//
+// Sequential-classifier-wins semantics are preserved by callers running
+// applyClassifier per classifier in declaration order — output of
+// classifier N feeds classifier N+1, so an earlier classifier's
+// tokenisation shields its region from later classifier regexes (most
+// of which don't match the literal "<REDACTED:…>" character set).
+//
+// Three predicates gate emit() in the same order as the original:
+//  1. extract span (capture group 1 if present, else whole match)
+//  2. minLen <= len(span) <= maxLen (maxLen=0 ⇒ no upper bound)
+//  3. negative regex must NOT match span (defensive — protectNegatives
+//     normally substitutes such spans with NUL placeholders before this
+//     runs, but the check is repeated here so callers that skip
+//     protection still get correct semantics).
+func applyClassifier(text string, c classifier, emit func(span string) string) string {
+	return c.re.ReplaceAllStringFunc(text, func(matched string) string {
+		span := matched
+		subs := c.re.FindStringSubmatch(matched)
+		if len(subs) > 1 {
+			span = subs[1]
+		}
+		l := len(span)
+		if l < c.minLen || (c.maxLen > 0 && l > c.maxLen) {
+			return matched
+		}
+		if c.negative != nil && c.negative.MatchString(span) {
+			return matched
+		}
+		token := emit(span)
+		if len(subs) > 1 {
+			subIdx := c.re.FindStringSubmatchIndex(matched)
+			if len(subIdx) >= 4 {
+				prefix := matched[:subIdx[2]]
+				suffix := matched[subIdx[3]:]
+				return prefix + token + suffix
+			}
+		}
+		return token
+	})
+}
+
+// protectedGuard is one (placeholder, original) pair produced by
+// protectNegatives and consumed by restoreProtected.
+type protectedGuard struct {
+	placeholder string
+	original    string
+}
+
+// protectNegatives implements pass 1 of the redaction pipeline:
+// substitute every span that matches a classifier's negative regex
+// with a NUL-delimited placeholder so subsequent classification runs
+// can't redact it. Returns the placeholdered text plus the guard
+// table that pass 3 (restoreProtected) uses to put the originals back.
+//
+// Extracted alongside applyClassifier so the future LLM pipeline
+// reuses the protect/restore envelope without duplicating the shape.
+func protectNegatives(text string, patterns []classifier) (string, []protectedGuard) {
+	var guards []protectedGuard
+	working := text
+	for _, c := range patterns {
+		if c.negative == nil {
+			continue
+		}
+		working = c.re.ReplaceAllStringFunc(working, func(matched string) string {
+			span := matched
+			if subs := c.re.FindStringSubmatch(matched); len(subs) > 1 {
+				span = subs[1]
+			}
+			if !c.negative.MatchString(span) {
+				return matched
+			}
+			ph := fmt.Sprintf("\x00PROT%d\x00", len(guards))
+			guards = append(guards, protectedGuard{placeholder: ph, original: matched})
+			return ph
+		})
+	}
+	return working, guards
+}
+
+// restoreProtected reverses protectNegatives — substituting each
+// guard's placeholder back to its original string.
+func restoreProtected(text string, guards []protectedGuard) string {
+	for _, g := range guards {
+		text = strings.Replace(text, g.placeholder, g.original, 1)
+	}
+	return text
+}
+
 // redactInternal implements both Redact and RedactWithMap.
 //
 // A span that matches a classifier's negative regex is globally protected
@@ -105,11 +204,18 @@ func RedactBytes(b []byte) []byte {
 // restored after all have run. This prevents a broader classifier (e.g. Phone
 // matching a 10-digit subsequence of a 16-digit CC) from redacting a span
 // that a more specific classifier has already flagged as known-safe.
+//
+// Refactored in Phase 13 WS#13.G prep: the per-classifier match+replace
+// closure is now applyClassifier; the negative-protection envelope is
+// protectNegatives + restoreProtected. Output is byte-for-byte identical
+// to the previous implementation — TestRedactGoldenFile is the
+// load-bearing invariant guarding that.
 func redactInternal(text string, buildMap bool) (string, map[string]string) {
 	global.initKey()
 	global.mu.RLock()
 	key := global.key
 	initErr := global.keyInitErr
+	patterns := global.patterns
 	global.mu.RUnlock()
 
 	if initErr != nil {
@@ -121,72 +227,26 @@ func redactInternal(text string, buildMap bool) (string, map[string]string) {
 		revealMap = make(map[string]string)
 	}
 
-	// Pass 1: protect spans that hit a negative regex. Placeholders use
-	// NUL bytes which no classifier regex can match, so they pass through
-	// classification untouched.
-	type protected struct{ placeholder, original string }
-	var guards []protected
-	working := text
-	for _, c := range global.patterns {
-		if c.negative == nil {
-			continue
-		}
-		working = c.re.ReplaceAllStringFunc(working, func(match string) string {
-			span := match
-			if subs := c.re.FindStringSubmatch(match); len(subs) > 1 {
-				span = subs[1]
-			}
-			if !c.negative.MatchString(span) {
-				return match
-			}
-			ph := fmt.Sprintf("\x00PROT%d\x00", len(guards))
-			guards = append(guards, protected{placeholder: ph, original: match})
-			return ph
-		})
-	}
+	// Pass 1: protect negative-regex matches with NUL placeholders.
+	working, guards := protectNegatives(text, patterns)
 
-	// Pass 2: run classifier loop on the placeholdered text. The negative
-	// check remains as a defensive no-op — spans that would have matched
-	// are already placeholder-substituted and no longer look like anything.
-	result := working
-	for _, c := range global.patterns {
-		result = c.re.ReplaceAllStringFunc(result, func(match string) string {
-			span := match
-			subs := c.re.FindStringSubmatch(match)
-			if len(subs) > 1 {
-				span = subs[1]
-			}
-
-			l := len(span)
-			if l < c.minLen || (c.maxLen > 0 && l > c.maxLen) {
-				return match
-			}
-			if c.negative != nil && c.negative.MatchString(span) {
-				return match
-			}
-
+	// Pass 2: run each classifier in declaration order. Output of the
+	// previous classifier feeds the next so an earlier classifier's
+	// tokens shield their regions from a later classifier's regex —
+	// this is the load-bearing invariant TestRedactGoldenFile guards.
+	for _, c := range patterns {
+		c := c // capture for closure
+		working = applyClassifier(working, c, func(span string) string {
 			token := makeToken(key, c.category, span)
 			if buildMap {
 				revealMap[token] = span
-			}
-
-			if len(subs) > 1 {
-				subIdx := c.re.FindStringSubmatchIndex(match)
-				if len(subIdx) >= 4 {
-					prefix := match[:subIdx[2]]
-					suffix := match[subIdx[3]:]
-					return prefix + token + suffix
-				}
 			}
 			return token
 		})
 	}
 
 	// Pass 3: restore protected spans in their original form.
-	for _, g := range guards {
-		result = strings.Replace(result, g.placeholder, g.original, 1)
-	}
-	return result, revealMap
+	return restoreProtected(working, guards), revealMap
 }
 
 // makeToken returns "<REDACTED:CATEGORY:xxxxxx>" where xxxxxx is the first 6

--- a/internal/secret/redaction_helpers_test.go
+++ b/internal/secret/redaction_helpers_test.go
@@ -1,0 +1,237 @@
+package secret
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// Direct tests for the helpers extracted from redactInternal in Phase 13
+// WS#13.G prep — applyClassifier, protectNegatives, restoreProtected.
+//
+// The end-to-end invariant (byte-for-byte equivalent output to the
+// pre-refactor implementation) is guarded by TestRedactGoldenFile in
+// redaction_test.go. These tests target each helper in isolation so a
+// future regression points the reviewer at the exact broken layer
+// rather than just a different SHA on the golden fixture.
+
+// ---------------------------------------------------------------------------
+// applyClassifier
+// ---------------------------------------------------------------------------
+
+func TestApplyClassifier_NoCaptureGroup_ReplacesWholeMatch(t *testing.T) {
+	t.Parallel()
+	c := classifier{
+		category: "TEST",
+		re:       regexp.MustCompile(`AKIA[A-Z0-9]{16}`),
+		minLen:   20,
+		maxLen:   20,
+	}
+	out := applyClassifier(
+		"key=AKIAIOSFODNN7EXAMPLE end",
+		c,
+		func(span string) string { return "<TOK:" + span[:4] + ">" },
+	)
+	if out != "key=<TOK:AKIA> end" {
+		t.Errorf("got %q", out)
+	}
+}
+
+func TestApplyClassifier_CaptureGroup_ReplacesOnlyTheGroup(t *testing.T) {
+	t.Parallel()
+	// Mimics the bearer-token regex shape: prefix + captured value.
+	c := classifier{
+		category: "BEARER",
+		re:       regexp.MustCompile(`(?i)bearer\s+([A-Za-z0-9]+)`),
+		minLen:   1,
+		maxLen:   4096,
+	}
+	out := applyClassifier(
+		"Authorization: Bearer abc123 next",
+		c,
+		func(span string) string { return "<TOK:" + span + ">" },
+	)
+	// "Bearer " surrounding context is preserved; only "abc123" is replaced.
+	if out != "Authorization: Bearer <TOK:abc123> next" {
+		t.Errorf("got %q", out)
+	}
+}
+
+func TestApplyClassifier_LengthBounds_RejectTooShort(t *testing.T) {
+	t.Parallel()
+	c := classifier{
+		category: "TEST",
+		re:       regexp.MustCompile(`\d+`),
+		minLen:   5,
+	}
+	out := applyClassifier(
+		"id 42 vs 1234567",
+		c,
+		func(span string) string { return "<TOK>" },
+	)
+	// "42" is too short; "1234567" is long enough.
+	if out != "id 42 vs <TOK>" {
+		t.Errorf("got %q", out)
+	}
+}
+
+func TestApplyClassifier_LengthBounds_RejectTooLong(t *testing.T) {
+	t.Parallel()
+	c := classifier{
+		category: "TEST",
+		re:       regexp.MustCompile(`\d+`),
+		minLen:   1,
+		maxLen:   3,
+	}
+	out := applyClassifier(
+		"short 42 long 1234567",
+		c,
+		func(span string) string { return "<TOK>" },
+	)
+	// "42" passes; "1234567" exceeds maxLen and is left alone.
+	if out != "short <TOK> long 1234567" {
+		t.Errorf("got %q", out)
+	}
+}
+
+func TestApplyClassifier_NegativeRegex_RejectsMatch(t *testing.T) {
+	t.Parallel()
+	c := classifier{
+		category: "EMAIL",
+		re:       regexp.MustCompile(`(?i)[a-z0-9.]+@[a-z0-9.]+`),
+		negative: regexp.MustCompile(`(?i)@example\.(com|org|net)$`),
+		minLen:   3,
+		maxLen:   254,
+	}
+	out := applyClassifier(
+		"real alice@corp.io and docs bob@example.com",
+		c,
+		func(span string) string { return "<TOK>" },
+	)
+	// Real email gets redacted; docs example does not.
+	if !strings.Contains(out, "<TOK>") {
+		t.Errorf("real email not redacted: %q", out)
+	}
+	if !strings.Contains(out, "bob@example.com") {
+		t.Errorf("negative-matching email was redacted: %q", out)
+	}
+}
+
+func TestApplyClassifier_EmitTokenIsByteIdentical(t *testing.T) {
+	t.Parallel()
+	// Asserts emit() output is interpolated verbatim — the helper must
+	// not transform whatever the caller returned. Critical for the
+	// future LLM pipeline whose tokens differ in shape from HMAC ones.
+	c := classifier{
+		category: "TEST",
+		re:       regexp.MustCompile(`secret`),
+		minLen:   1,
+	}
+	emitted := "<REDACTED:test:42>"
+	out := applyClassifier("a secret here", c, func(span string) string { return emitted })
+	if out != "a "+emitted+" here" {
+		t.Errorf("got %q, want %q", out, "a "+emitted+" here")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// protectNegatives + restoreProtected — round-trip + isolation
+// ---------------------------------------------------------------------------
+
+func TestProtectAndRestore_RoundTrip(t *testing.T) {
+	t.Parallel()
+	patterns := []classifier{
+		{
+			category: "EMAIL",
+			re:       regexp.MustCompile(`(?i)[a-z0-9.]+@[a-z0-9.]+`),
+			negative: regexp.MustCompile(`(?i)@example\.com$`),
+			minLen:   3,
+			maxLen:   254,
+		},
+	}
+	original := "alice@corp.io and bob@example.com"
+	working, guards := protectNegatives(original, patterns)
+
+	// alice@corp.io must remain intact (its email regex matched but
+	// negative did not). bob@example.com must be replaced with a NUL
+	// placeholder.
+	if !strings.Contains(working, "alice@corp.io") {
+		t.Errorf("real email mangled by protect pass: %q", working)
+	}
+	if strings.Contains(working, "bob@example.com") {
+		t.Errorf("docs email was not replaced: %q", working)
+	}
+	if len(guards) != 1 {
+		t.Errorf("guard count = %d, want 1", len(guards))
+	}
+
+	// Restoration recovers the original byte-for-byte.
+	restored := restoreProtected(working, guards)
+	if restored != original {
+		t.Errorf("round-trip mismatch:\n  original:  %q\n  restored: %q", original, restored)
+	}
+}
+
+func TestProtectNegatives_NoNegativeRegex_IsNoOp(t *testing.T) {
+	t.Parallel()
+	patterns := []classifier{
+		{
+			category: "TEST",
+			re:       regexp.MustCompile(`secret`),
+			negative: nil,
+			minLen:   1,
+		},
+	}
+	in := "a secret value"
+	working, guards := protectNegatives(in, patterns)
+	if working != in {
+		t.Errorf("protect pass mutated text without negative regex: %q", working)
+	}
+	if len(guards) != 0 {
+		t.Errorf("guard count = %d, want 0", len(guards))
+	}
+}
+
+func TestProtectNegatives_PlaceholdersAreImmuneToReclassification(t *testing.T) {
+	t.Parallel()
+	// The whole point of pass 1 → pass 2: a span protected by pass 1
+	// must NOT be re-matched by ANY classifier in pass 2. Verify by
+	// running applyClassifier against the placeholdered output and
+	// asserting the placeholder survives unchanged.
+	patterns := []classifier{
+		{
+			category: "EMAIL",
+			re:       regexp.MustCompile(`(?i)[a-z0-9.]+@[a-z0-9.]+`),
+			negative: regexp.MustCompile(`(?i)@example\.com$`),
+			minLen:   3,
+			maxLen:   254,
+		},
+	}
+	working, guards := protectNegatives("docs bob@example.com", patterns)
+	// Now run a hypothetical aggressive classifier that would match
+	// any "bob" substring.
+	aggro := classifier{
+		category: "AGG",
+		re:       regexp.MustCompile(`bob`),
+		minLen:   1,
+	}
+	out := applyClassifier(working, aggro, func(span string) string { return "<HIT>" })
+	// Restore — final output must STILL contain the original
+	// bob@example.com because protectNegatives shielded it.
+	final := restoreProtected(out, guards)
+	if !strings.Contains(final, "bob@example.com") {
+		t.Errorf("protected span was mutated by later classifier: %q", final)
+	}
+	if strings.Contains(final, "<HIT>") {
+		t.Errorf("aggressive classifier should not have matched inside placeholder: %q", final)
+	}
+}
+
+func TestRestoreProtected_EmptyGuards_IsNoOp(t *testing.T) {
+	t.Parallel()
+	in := "no guards here"
+	out := restoreProtected(in, nil)
+	if out != in {
+		t.Errorf("empty guards mutated text: got %q, want %q", out, in)
+	}
+}


### PR DESCRIPTION
## Summary

Phase 13 WS#13.G prep — extracts the three reusable building blocks of `redactInternal` into named helpers so the future `RedactForLLM` (per the security-engineer specialist plan stored in claude-flow memory under `phase13-plan/ws-G/plan`) can plug in a different emit-token strategy without copy-pasting the match-finding + negative-protection code.

**No observable behaviour change.** Output is byte-for-byte identical to the pre-refactor implementation; the existing `TestRedactGoldenFile` (which guards a SHA-256 of the golden fixture's redacted output) still passes with the same expected hash.

## What was extracted

```go
applyClassifier(text, c, emit) string
  // per-classifier match+replace loop; emit() decides the replacement
  // for each accepted span. Preserves: capture-group-vs-whole-match
  // span selection, minLen/maxLen bounds, negative-regex defensive check,
  // capture-group prefix/suffix preservation.

protectNegatives(text, patterns) (string, []protectedGuard)
  // pass 1: NUL-placeholder spans that match a classifier's negative regex.

restoreProtected(text, guards) string
  // pass 3: undo protectNegatives.

type protectedGuard struct { placeholder, original string }
```

`redactInternal` is now 3 lines of pipeline orchestration (`protect → applyClassifier × N → restore`) instead of 80 lines of inline closures.

## Why `applyClassifier` rather than `findMatches`

The security-engineer plan originally envisioned a `findMatches(text, cats []Category) []match` helper that returns all candidate spans in one pass. **I tried that first and had to walk it back.** Concretely, the OpenAI API key in `OPENAI_API_KEY=sk-proj-abcdefghijklmnopqrstuvwxyz0123456789ABCDE`:

| Pipeline | Behaviour |
|---|---|
| **Pre-refactor** (sequential) | Phone runs first (declaration order), redacts the embedded `0123456789` run, creating a `<REDACTED:PHONE:…>` token inside the key. API_KEY then runs — its capture-group character class doesn't include `<`, so it captures only the prefix → **two tokens** output. |
| **`findMatches`** (parallel) | Sees API_KEY as the earlier-starting span (whole 50-char value) and drops Phone as overlapping → **one token** output. |

That's a real semantic change in a security-sensitive subsystem. The byte-for-byte equivalence guard caught it on the first build — the redacted-fixture SHA changed from `0e169761…` to `e7a91a2f…`.

`applyClassifier` is the correct abstraction: it preserves sequential semantics **by definition** (it IS the pre-refactor closure, just lifted into a function), and both the HMAC pipeline and the future LLM pipeline iterate over classifiers themselves — calling `applyClassifier` once per classifier with their respective `emit()`.

## Tests

**10 new cases** in `redaction_helpers_test.go` targeting each helper in isolation:

- `TestApplyClassifier_NoCaptureGroup_ReplacesWholeMatch`
- `TestApplyClassifier_CaptureGroup_ReplacesOnlyTheGroup`
- `TestApplyClassifier_LengthBounds_RejectTooShort`
- `TestApplyClassifier_LengthBounds_RejectTooLong`
- `TestApplyClassifier_NegativeRegex_RejectsMatch`
- `TestApplyClassifier_EmitTokenIsByteIdentical`
- `TestProtectAndRestore_RoundTrip`
- `TestProtectNegatives_NoNegativeRegex_IsNoOp`
- `TestProtectNegatives_PlaceholdersAreImmuneToReclassification`
- `TestRestoreProtected_EmptyGuards_IsNoOp`

The end-to-end byte-for-byte invariant is still guarded by the existing `TestRedactGoldenFile`. These new tests target each helper in isolation so a future regression points the reviewer at the exact broken layer rather than just a different SHA.

## Verification — all green

| Check | Result |
|---|---|
| `go build ./...` | ✅ |
| `go test ./...` (18 packages) | ✅ all pass |
| `TestRedactGoldenFile` SHA-256 | ✅ unchanged from pre-refactor |
| `gofmt -l .` | ✅ clean |
| `golangci-lint run` | ✅ 0 issues |

## What this PR does NOT include

- The `RedactForLLM` / `UnRedactResponse` functions and their per-conversation reversible token format. Those land in a separate PR on top of this refactor — the contract is `applyClassifier` with a counter-based `emit()` per `phase13-plan/ws-G/plan`.
- The recognizer extensions (Slack tokens, Stripe keys, GitHub PATs, GCP service-account JSON) the security-engineer flagged as MUST-land-with-G. Same follow-up PR.
- Any wiring into `internal/llm/client.go`. Same follow-up PR.

## Phase 13 substrate state after this lands

```
WS#13.F deep-links             ✅ shipped (#33)
WS#13.A Tasks UI polish         🟡 PR #34 open
WS#13.E cookbook stubs          🟡 PR #35 open
WS#13.G applyClassifier prep    🟡 this PR
WS#13.G RedactForLLM            plan in claude-flow memory phase13-plan/ws-G/plan
WS#13.B RAG                     plan in phase13-plan/ws-B/plan
WS#13.C Marketplace             plan in phase13-plan/ws-C/plan
WS#13.D Gmail tool              plan in phase13-plan/ws-D-gmail/plan
WS#13.E aria scrape             plan in phase13-plan/ws-E/plan
```

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)