### PR TITLE
feat(secret): WS#13.G — RedactForLLM + ReversibleMap + UnRedactResponse

### DIFF
--- a/internal/secret/llm.go
+++ b/internal/secret/llm.go
@@ -1,0 +1,238 @@
+package secret
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// Phase 13 WS#13.G — LLM-bound prompt redaction.
+//
+// The HMAC pipeline (Redact / RedactWithMap) is the right tool for
+// storage paths: tokens are deterministic across calls, so a receipt
+// referencing `<REDACTED:EMAIL:a1b2c3>` correlates with another
+// receipt redacting the same email. That's exactly what the receipts
+// + task_events + plan_json columns need.
+//
+// For LLM consumption the requirements differ:
+//
+//   - Tokens must be human-readable so the model can reason about them
+//     ("respond to the first email" vs "respond to <REDACTED:EMAIL:a1b2c3>").
+//     Counter-based tokens (`<REDACTED:EMAIL:1>`) read much better.
+//   - Tokens must NOT be deterministic across conversations — a token
+//     in conversation A leaking into conversation B's mapping would
+//     un-redact to the wrong plaintext. Per-mapping counters reset
+//     and are scoped to a single ReversibleMap.
+//   - Identical plaintext within ONE mapping gets the SAME token so
+//     the model sees consistency turn-to-turn (otherwise "the email
+//     I mentioned earlier" drifts from `:1` to `:7`).
+//   - The mapping must be reversible — UnRedactResponse turns assistant
+//     output that mentions tokens back into plaintext for the user, so
+//     redaction is invisible at the UX layer.
+//
+// Threat model — closed:
+//   - Provider-side prompt logging (provider only sees tokens).
+//   - Network-tap exposure (TLS terminates at the provider).
+//   - Cross-conversation correlation by the provider (counter tokens
+//     are per-mapping, deterministic ONLY within one mapping).
+//
+// Threat model — explicitly NOT closed:
+//   - Provider runtime exposure to the model itself (the model still
+//     reasons about plaintext indirectly via counter tokens; we only
+//     change the wire/log shape).
+//   - Provider log retention (procurement / contract control).
+//   - RAG embedding privacy (out of scope; embeddings stay local).
+//   - Side channels (token count, response time, response length).
+
+// Policy controls which categories RedactForLLM redacts. An empty /
+// zero-value Policy redacts every built-in category (default-on for
+// safety). Callers that want narrower coverage pass a non-nil
+// Categories map listing the specific categories to act on.
+type Policy struct {
+	// Categories — when non-nil, only categories whose key is true
+	// are redacted. nil/empty = redact everything (the safe default).
+	Categories map[Category]bool
+}
+
+// allows reports whether category c should be redacted under p.
+func (p Policy) allows(c Category) bool {
+	if len(p.Categories) == 0 {
+		return true
+	}
+	return p.Categories[c]
+}
+
+// ReversibleMap is the per-conversation side-table mapping LLM-format
+// redaction tokens back to their original plaintext. Allocated by the
+// caller via NewReversibleMap, populated by RedactForLLM, consumed by
+// UnRedactResponse.
+//
+// Lifetime is intentionally short: the mapping holds plaintext in
+// memory, so callers must drop the pointer once the request stream
+// closes. Never persist a ReversibleMap; never share one across
+// conversations.
+type ReversibleMap struct {
+	byToken    map[string]string // token text → original plaintext
+	byCategory map[Category]int  // category → highest counter assigned
+	// dedupKey holds (category, plaintext) → token so identical
+	// plaintexts within one mapping reuse a token.
+	dedupKey map[string]string
+}
+
+// NewReversibleMap allocates an empty mapping. Callers typically do
+// `mapping := secret.NewReversibleMap(); defer mapping.Clear()` so
+// plaintext doesn't outlive the request.
+func NewReversibleMap() *ReversibleMap {
+	return &ReversibleMap{
+		byToken:    make(map[string]string),
+		byCategory: make(map[Category]int),
+		dedupKey:   make(map[string]string),
+	}
+}
+
+// Size returns the number of distinct tokens in the mapping. Useful
+// for the redaction-diff UI banner ("3 secrets redacted this turn").
+func (m *ReversibleMap) Size() int {
+	if m == nil {
+		return 0
+	}
+	return len(m.byToken)
+}
+
+// Lookup returns the plaintext for token, or ("", false) if the token
+// is not in this mapping.
+func (m *ReversibleMap) Lookup(token string) (string, bool) {
+	if m == nil {
+		return "", false
+	}
+	plain, ok := m.byToken[token]
+	return plain, ok
+}
+
+// Categories returns the set of categories that have at least one
+// token in the mapping. Order is unspecified.
+func (m *ReversibleMap) Categories() []Category {
+	if m == nil {
+		return nil
+	}
+	out := make([]Category, 0, len(m.byCategory))
+	for c := range m.byCategory {
+		out = append(out, c)
+	}
+	return out
+}
+
+// Clear zeroes the mapping. Call when the request scope ends so
+// plaintext doesn't linger in memory longer than necessary.
+func (m *ReversibleMap) Clear() {
+	if m == nil {
+		return
+	}
+	for k := range m.byToken {
+		delete(m.byToken, k)
+	}
+	for k := range m.byCategory {
+		delete(m.byCategory, k)
+	}
+	for k := range m.dedupKey {
+		delete(m.dedupKey, k)
+	}
+}
+
+// RedactForLLM rewrites text by replacing every detected secret with a
+// per-mapping counter token of the shape `<REDACTED:CATEGORY:N>`.
+//
+// Identical plaintext within one mapping reuses the same token —
+// "respond to <REDACTED:EMAIL:1> from corp.example" stays consistent
+// even if the same email appears five times in the prompt history.
+//
+// `mapping` must be non-nil. Multiple calls with the same mapping
+// continue the per-category counter, so iterating over a Message slice
+// produces a globally-consistent token-set across the whole prompt.
+//
+// On redaction-subsystem init failure (rare — keyring fundamentally
+// unavailable), RedactForLLM passes text through unchanged. Callers
+// that want fail-closed behaviour should check Ready() first and
+// refuse to send the prompt; the default fail-open posture is chosen
+// to avoid nuking the prompt over a transient failure.
+func RedactForLLM(text string, mapping *ReversibleMap, policy Policy) string {
+	if mapping == nil {
+		// Defensive — callers that misuse this should crash visibly
+		// rather than silently leak plaintext. Phase 13 design
+		// prefers explicit failure here.
+		panic("secret: RedactForLLM called with nil mapping")
+	}
+
+	global.initKey()
+	global.mu.RLock()
+	initErr := global.keyInitErr
+	patterns := global.patterns
+	global.mu.RUnlock()
+	if initErr != nil {
+		// Fail-open: passing the un-redacted prompt through is no
+		// worse than the pre-WS#13.G state (which always sent
+		// un-redacted prompts to the provider). A subsequent Ready()
+		// check at the gateway can refuse new requests.
+		return text
+	}
+
+	// Pass 1: protect negative-regex matches (mirrors HMAC pipeline
+	// — the same negative-regex policy applies regardless of which
+	// token format we end up emitting).
+	working, guards := protectNegatives(text, patterns)
+
+	// Pass 2: per-classifier emit using counter tokens, with per-
+	// (category, plaintext) deduplication so identical secrets reuse
+	// a token within this mapping.
+	for _, c := range patterns {
+		c := c
+		if !policy.allows(c.category) {
+			continue
+		}
+		working = applyClassifier(working, c, func(span string) string {
+			key := string(c.category) + "\x00" + span
+			if existing, ok := mapping.dedupKey[key]; ok {
+				return existing
+			}
+			mapping.byCategory[c.category]++
+			n := mapping.byCategory[c.category]
+			token := fmt.Sprintf("<REDACTED:%s:%d>", c.category, n)
+			mapping.byToken[token] = span
+			mapping.dedupKey[key] = token
+			return token
+		})
+	}
+
+	// Pass 3: restore protected spans.
+	return restoreProtected(working, guards)
+}
+
+// llmTokenRe matches the per-mapping counter-token shape produced by
+// RedactForLLM. The HMAC pipeline emits 6-char hex suffixes which
+// don't match this pattern, so UnRedactResponse won't touch HMAC
+// tokens that may have leaked into a response.
+var llmTokenRe = regexp.MustCompile(`<REDACTED:[A-Z_]+:\d+>`)
+
+// UnRedactResponse replaces every counter-token literal in text with
+// its original plaintext from the mapping. Unknown tokens (not in the
+// mapping) are left as literal text — fail-closed: we never invent a
+// substitution.
+//
+// Designed for assistant-message post-processing: the model may quote
+// a token verbatim when discussing the redacted entity, and the user
+// expects to see the original value rendered. Per Phase 13 D6 / Q4,
+// callers gate this on `cfg.PromptRedaction.ShowRedacted == false`
+// (the default) — when ShowRedacted is true, callers leave the token
+// visible.
+//
+// `mapping` may be nil; in that case text is returned unchanged.
+func UnRedactResponse(text string, mapping *ReversibleMap) string {
+	if mapping == nil || mapping.Size() == 0 {
+		return text
+	}
+	return llmTokenRe.ReplaceAllStringFunc(text, func(token string) string {
+		if plain, ok := mapping.byToken[token]; ok {
+			return plain
+		}
+		return token
+	})
+}

--- a/internal/secret/llm_test.go
+++ b/internal/secret/llm_test.go
@@ -1,0 +1,395 @@
+package secret
+
+import (
+	"strings"
+	"testing"
+)
+
+// Tests for the Phase 13 WS#13.G LLM-redaction pipeline. The HMAC
+// pipeline already has comprehensive coverage in redaction_test.go;
+// these tests focus on the surface that's specific to RedactForLLM /
+// UnRedactResponse / ReversibleMap.
+
+// ---------------------------------------------------------------------------
+// RedactForLLM — counter scoping, dedup, policy filter
+// ---------------------------------------------------------------------------
+
+func TestRedactForLLM_HappyPath(t *testing.T) {
+	t.Parallel()
+	mapping := NewReversibleMap()
+	out := RedactForLLM("contact alice@corp.example for details", mapping, Policy{})
+	if !strings.Contains(out, "<REDACTED:EMAIL:1>") {
+		t.Errorf("expected email:1 token in output, got %q", out)
+	}
+	if mapping.Size() != 1 {
+		t.Errorf("Size = %d, want 1", mapping.Size())
+	}
+	plain, ok := mapping.Lookup("<REDACTED:EMAIL:1>")
+	if !ok || plain != "alice@corp.example" {
+		t.Errorf("Lookup returned (%q, %v), want (\"alice@corp.example\", true)", plain, ok)
+	}
+}
+
+func TestRedactForLLM_CountersScopePerCategory(t *testing.T) {
+	t.Parallel()
+	mapping := NewReversibleMap()
+	out := RedactForLLM(
+		"alice@corp.example bob@corp.example carol@corp.example",
+		mapping,
+		Policy{},
+	)
+	if !strings.Contains(out, "<REDACTED:EMAIL:1>") ||
+		!strings.Contains(out, "<REDACTED:EMAIL:2>") ||
+		!strings.Contains(out, "<REDACTED:EMAIL:3>") {
+		t.Errorf("expected email:1/2/3 tokens, got %q", out)
+	}
+}
+
+func TestRedactForLLM_DedupesIdenticalPlaintext(t *testing.T) {
+	t.Parallel()
+	// Same email mentioned twice — must reuse the same counter token
+	// so the LLM sees consistency ("the email I mentioned").
+	mapping := NewReversibleMap()
+	out := RedactForLLM(
+		"reply to alice@corp.example and cc alice@corp.example",
+		mapping,
+		Policy{},
+	)
+	count := strings.Count(out, "<REDACTED:EMAIL:1>")
+	if count != 2 {
+		t.Errorf("expected email:1 to appear twice (dedup), got %d in %q", count, out)
+	}
+	if strings.Contains(out, "<REDACTED:EMAIL:2>") {
+		t.Errorf("dedup failed — same plaintext got two tokens: %q", out)
+	}
+	if mapping.Size() != 1 {
+		t.Errorf("Size = %d, want 1 (deduped)", mapping.Size())
+	}
+}
+
+func TestRedactForLLM_CountersContinueAcrossCalls(t *testing.T) {
+	t.Parallel()
+	// One mapping shared across two calls — counters must continue.
+	mapping := NewReversibleMap()
+	out1 := RedactForLLM("alice@corp.example", mapping, Policy{})
+	out2 := RedactForLLM("bob@corp.example", mapping, Policy{})
+	if !strings.Contains(out1, "<REDACTED:EMAIL:1>") {
+		t.Errorf("first call: expected email:1, got %q", out1)
+	}
+	if !strings.Contains(out2, "<REDACTED:EMAIL:2>") {
+		t.Errorf("second call: expected email:2 (counter continued), got %q", out2)
+	}
+	if mapping.Size() != 2 {
+		t.Errorf("Size = %d, want 2", mapping.Size())
+	}
+}
+
+func TestRedactForLLM_DistinctCategoriesGetIndependentCounters(t *testing.T) {
+	t.Parallel()
+	mapping := NewReversibleMap()
+	out := RedactForLLM(
+		"call 415-555-0100 or email alice@corp.example",
+		mapping,
+		Policy{},
+	)
+	// Both should be :1 since each category counts independently.
+	if !strings.Contains(out, "<REDACTED:PHONE:1>") {
+		t.Errorf("expected phone:1, got %q", out)
+	}
+	if !strings.Contains(out, "<REDACTED:EMAIL:1>") {
+		t.Errorf("expected email:1, got %q", out)
+	}
+}
+
+func TestRedactForLLM_PolicyFilter(t *testing.T) {
+	t.Parallel()
+	// Only redact emails. Phone in the same input should pass through.
+	mapping := NewReversibleMap()
+	policy := Policy{Categories: map[Category]bool{CatEmail: true}}
+	out := RedactForLLM(
+		"call 415-555-0100 or email alice@corp.example",
+		mapping,
+		policy,
+	)
+	if strings.Contains(out, "<REDACTED:PHONE") {
+		t.Errorf("phone redacted despite policy filter: %q", out)
+	}
+	if !strings.Contains(out, "<REDACTED:EMAIL:1>") {
+		t.Errorf("email not redacted: %q", out)
+	}
+	if !strings.Contains(out, "415-555-0100") {
+		t.Errorf("phone plaintext missing: %q", out)
+	}
+}
+
+func TestRedactForLLM_NegativeRegexHonored(t *testing.T) {
+	t.Parallel()
+	// docs-email negative regex should keep example.com addresses intact.
+	mapping := NewReversibleMap()
+	out := RedactForLLM(
+		"real alice@corp.io and docs bob@example.com",
+		mapping,
+		Policy{},
+	)
+	if !strings.Contains(out, "<REDACTED:EMAIL:1>") {
+		t.Errorf("real email not redacted: %q", out)
+	}
+	if !strings.Contains(out, "bob@example.com") {
+		t.Errorf("docs email was redacted despite negative regex: %q", out)
+	}
+}
+
+func TestRedactForLLM_NilMappingPanics(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic on nil mapping; recovered nil")
+		}
+	}()
+	_ = RedactForLLM("alice@corp.example", nil, Policy{})
+}
+
+func TestRedactForLLM_EmptyText(t *testing.T) {
+	t.Parallel()
+	mapping := NewReversibleMap()
+	if out := RedactForLLM("", mapping, Policy{}); out != "" {
+		t.Errorf("empty input → %q, want empty", out)
+	}
+	if mapping.Size() != 0 {
+		t.Errorf("Size = %d, want 0", mapping.Size())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// UnRedactResponse — round-trip + safety
+// ---------------------------------------------------------------------------
+
+func TestUnRedactResponse_RoundTrip(t *testing.T) {
+	t.Parallel()
+	// Property: for any input text, un-redacting the redacted output
+	// yields back the original text byte-for-byte.
+	cases := []string{
+		"contact alice@corp.example",
+		"call 415-555-0100 then email alice@corp.example",
+		"three emails: a@x.io b@y.io c@z.io",
+		"plain text without any secrets",
+		"",
+		`{"email":"alice@corp.example","phone":"415-555-0100"}`,
+		"AKIAIOSFODNN7EXAMPLE",
+	}
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			mapping := NewReversibleMap()
+			redacted := RedactForLLM(in, mapping, Policy{})
+			unredacted := UnRedactResponse(redacted, mapping)
+			if unredacted != in {
+				t.Errorf("round-trip failed:\n  in:        %q\n  redacted:  %q\n  unredact:  %q", in, redacted, unredacted)
+			}
+		})
+	}
+}
+
+func TestUnRedactResponse_AssistantMentionsToken(t *testing.T) {
+	t.Parallel()
+	// Realistic: model receives prompt with `<REDACTED:EMAIL:1>` and
+	// echoes the token in its response. UnRedactResponse must
+	// substitute back to plaintext for the user.
+	mapping := NewReversibleMap()
+	_ = RedactForLLM("contact alice@corp.example", mapping, Policy{})
+	assistantOutput := "I'll send a follow-up to <REDACTED:EMAIL:1> later today."
+	out := UnRedactResponse(assistantOutput, mapping)
+	if out != "I'll send a follow-up to alice@corp.example later today." {
+		t.Errorf("unredacted assistant output wrong: %q", out)
+	}
+}
+
+func TestUnRedactResponse_UnknownTokenPassthrough(t *testing.T) {
+	t.Parallel()
+	// A token that's not in the mapping (different conversation, hand-
+	// crafted by the model, etc.) must be left as-is rather than
+	// silently substituted with a guess.
+	mapping := NewReversibleMap()
+	_ = RedactForLLM("alice@corp.example", mapping, Policy{}) // populates email:1
+	out := UnRedactResponse(
+		"Reference <REDACTED:PHONE:99> from earlier",
+		mapping,
+	)
+	if !strings.Contains(out, "<REDACTED:PHONE:99>") {
+		t.Errorf("unknown token was substituted: %q", out)
+	}
+}
+
+func TestUnRedactResponse_DoesNotTouchHMACTokens(t *testing.T) {
+	t.Parallel()
+	// HMAC tokens have hex suffixes (`<REDACTED:EMAIL:a1b2c3>`) which
+	// the LLM-token regex (`<REDACTED:[A-Z_]+:\d+>`) doesn't match.
+	// Verify a leaked HMAC token in an assistant response doesn't get
+	// mangled.
+	mapping := NewReversibleMap()
+	_ = RedactForLLM("alice@corp.example", mapping, Policy{})
+	hmacToken := "<REDACTED:EMAIL:a1b2c3>" // hex, not LLM-format
+	out := UnRedactResponse("see "+hmacToken+" for context", mapping)
+	if !strings.Contains(out, hmacToken) {
+		t.Errorf("HMAC token mangled: %q", out)
+	}
+}
+
+func TestUnRedactResponse_NilMappingNoOp(t *testing.T) {
+	t.Parallel()
+	in := "contact <REDACTED:EMAIL:1>"
+	if out := UnRedactResponse(in, nil); out != in {
+		t.Errorf("nil mapping → %q, want %q (no-op)", out, in)
+	}
+}
+
+func TestUnRedactResponse_EmptyMappingNoOp(t *testing.T) {
+	t.Parallel()
+	mapping := NewReversibleMap()
+	in := "contact <REDACTED:EMAIL:1>"
+	if out := UnRedactResponse(in, mapping); out != in {
+		t.Errorf("empty mapping → %q, want %q (no-op)", out, in)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Mapping isolation — A and B don't leak
+// ---------------------------------------------------------------------------
+
+func TestReversibleMap_IsolationBetweenMappings(t *testing.T) {
+	t.Parallel()
+	mapA := NewReversibleMap()
+	mapB := NewReversibleMap()
+	_ = RedactForLLM("alice@corp.example", mapA, Policy{})
+	_ = RedactForLLM("bob@corp.example", mapB, Policy{})
+	// Both have :1 internally — but un-redacting A's text against B's
+	// mapping must NOT yield A's plaintext (counters collide → must miss).
+	got := UnRedactResponse("see <REDACTED:EMAIL:1>", mapB)
+	if strings.Contains(got, "alice") {
+		t.Errorf("mapping A's plaintext leaked through mapping B: %q", got)
+	}
+	// And B's mapping correctly returns bob.
+	gotB := UnRedactResponse("see <REDACTED:EMAIL:1>", mapB)
+	if !strings.Contains(gotB, "bob@corp.example") {
+		t.Errorf("mapping B failed to un-redact its own token: %q", gotB)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ReversibleMap accessor methods
+// ---------------------------------------------------------------------------
+
+func TestReversibleMap_Categories(t *testing.T) {
+	t.Parallel()
+	m := NewReversibleMap()
+	_ = RedactForLLM("alice@corp.example and 415-555-0100", m, Policy{})
+	cats := m.Categories()
+	if len(cats) != 2 {
+		t.Errorf("Categories len = %d, want 2", len(cats))
+	}
+	seen := map[Category]bool{}
+	for _, c := range cats {
+		seen[c] = true
+	}
+	if !seen[CatEmail] || !seen[CatPhone] {
+		t.Errorf("Categories missing entries: %v", cats)
+	}
+}
+
+func TestReversibleMap_Clear(t *testing.T) {
+	t.Parallel()
+	m := NewReversibleMap()
+	_ = RedactForLLM("alice@corp.example", m, Policy{})
+	if m.Size() != 1 {
+		t.Fatalf("pre-clear Size = %d, want 1", m.Size())
+	}
+	m.Clear()
+	if m.Size() != 0 {
+		t.Errorf("post-clear Size = %d, want 0", m.Size())
+	}
+	// After Clear, counters reset — next RedactForLLM call should
+	// emit email:1 again, not email:2.
+	_ = RedactForLLM("bob@corp.example", m, Policy{})
+	if _, ok := m.Lookup("<REDACTED:EMAIL:1>"); !ok {
+		t.Error("counter did not reset after Clear")
+	}
+	if _, ok := m.Lookup("<REDACTED:EMAIL:2>"); ok {
+		t.Error("counter incorrectly continued past Clear")
+	}
+}
+
+func TestReversibleMap_NilSafety(t *testing.T) {
+	t.Parallel()
+	var m *ReversibleMap // nil
+	if m.Size() != 0 {
+		t.Errorf("nil Size = %d, want 0", m.Size())
+	}
+	if _, ok := m.Lookup("<REDACTED:EMAIL:1>"); ok {
+		t.Error("nil Lookup returned ok=true")
+	}
+	if cats := m.Categories(); cats != nil {
+		t.Errorf("nil Categories = %v, want nil", cats)
+	}
+	m.Clear() // must not panic
+}
+
+// ---------------------------------------------------------------------------
+// Policy
+// ---------------------------------------------------------------------------
+
+func TestPolicy_AllowsAllByDefault(t *testing.T) {
+	t.Parallel()
+	p := Policy{}
+	for _, c := range []Category{
+		CatEmail, CatPhone, CatSSN, CatCreditCard,
+		CatAPIKey, CatJWT, CatAWSKeyID, CatBearer,
+	} {
+		if !p.allows(c) {
+			t.Errorf("default Policy disallowed %s", c)
+		}
+	}
+}
+
+func TestPolicy_NonEmptyMapFiltersExactly(t *testing.T) {
+	t.Parallel()
+	p := Policy{Categories: map[Category]bool{CatEmail: true}}
+	if !p.allows(CatEmail) {
+		t.Error("explicitly allowed category was disallowed")
+	}
+	if p.allows(CatPhone) {
+		t.Error("non-listed category was allowed")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Cross-pipeline isolation — RedactForLLM and Redact don't interfere
+// ---------------------------------------------------------------------------
+
+func TestRedactForLLM_DoesNotInterfereWithHMACPipeline(t *testing.T) {
+	t.Parallel()
+	in := "contact alice@corp.example"
+
+	// HMAC pipeline output (deterministic across calls, hex suffix).
+	hmac1 := Redact(in)
+	if !strings.Contains(hmac1, "<REDACTED:EMAIL:") {
+		t.Fatalf("HMAC pipeline didn't redact: %q", hmac1)
+	}
+
+	// LLM pipeline output (counter, distinct shape).
+	mapping := NewReversibleMap()
+	llm1 := RedactForLLM(in, mapping, Policy{})
+	if !strings.Contains(llm1, "<REDACTED:EMAIL:1>") {
+		t.Fatalf("LLM pipeline didn't redact: %q", llm1)
+	}
+
+	// HMAC and LLM tokens must NOT be identical strings.
+	if hmac1 == llm1 {
+		t.Errorf("HMAC and LLM redactions produced identical output: %q", hmac1)
+	}
+
+	// Calling Redact again still returns the same HMAC output —
+	// LLM redaction doesn't mutate the global redactor.
+	hmac2 := Redact(in)
+	if hmac1 != hmac2 {
+		t.Errorf("HMAC pipeline became non-deterministic after LLM call:\n  first: %q\n  second: %q", hmac1, hmac2)
+	}
+}


### PR DESCRIPTION
## Summary

Phase 13 WS#13.G core pipeline. Builds on the `applyClassifier` / `protectNegatives` / `restoreProtected` helpers landed in #37 and ships the LLM-side of secret redaction: per-conversation reversible counter tokens for prompts heading to the LLM provider.

Per the security-engineer specialist plan stored in claude-flow memory at `phase13-plan/ws-G/plan`. **The HMAC storage pipeline (`Redact` / `RedactBytes`) is unchanged** — its golden-fixture SHA-256 is the load-bearing invariant and it still passes.

## What's new

```go
// internal/secret/llm.go (new)

type Policy struct {
    Categories map[Category]bool   // empty/nil = all
}

type ReversibleMap struct { ... }   // opaque side-table
func NewReversibleMap() *ReversibleMap
func (m *ReversibleMap) Size() int
func (m *ReversibleMap) Lookup(token string) (string, bool)
func (m *ReversibleMap) Categories() []Category
func (m *ReversibleMap) Clear()

func RedactForLLM(text string, mapping *ReversibleMap, policy Policy) string
func UnRedactResponse(text string, mapping *ReversibleMap) string
```

### Token format

`<REDACTED:CATEGORY:N>` where `N` is a per-mapping, per-category counter starting at 1. **Identical plaintext within one mapping reuses the same token** so the LLM sees consistency turn-to-turn ("the email I mentioned earlier" stays at `:1`). The HMAC pipeline's hex-suffix tokens (`<REDACTED:EMAIL:a1b2c3>`) are a distinct shape and survive un-redaction untouched.

### ReversibleMap lifetime

Per chat **request**, not per session. Allocated in the request scope, dropped when the response stream closes. **Never persisted, never serialized over the wire.** Multi-turn flows allocate a fresh mapping per turn (counters reset) — this prevents a token from turn N getting un-redacted with the wrong plaintext if it leaks into turn M.

## Threat model

| | |
|---|---|
| **Closed by this WS** | Provider-side prompt logging · network-tap exposure · cross-conversation correlation by provider · screenshot/copy-paste of outgoing request body |
| **Explicitly NOT closed** | Provider runtime exposure to the model itself · provider log retention contracts · RAG embedding privacy (out of scope; embeddings stay local) · side channels (token count, response timing) |

## Tests — 18 cases

| Group | What |
|---|---|
| **RedactForLLM** | HappyPath · CountersScopePerCategory · DedupesIdenticalPlaintext · CountersContinueAcrossCalls · DistinctCategoriesGetIndependentCounters · PolicyFilter · NegativeRegexHonored · NilMappingPanics · EmptyText |
| **UnRedactResponse** | **RoundTrip property test** (7 inputs) · AssistantMentionsToken realistic flow · UnknownTokenPassthrough (fail-closed) · DoesNotTouchHMACTokens · NilMappingNoOp · EmptyMappingNoOp |
| **ReversibleMap** | IsolationBetweenMappings (A's token ≠ B's plaintext) · Categories · Clear (counters reset) · NilSafety |
| **Policy** | AllowsAllByDefault · NonEmptyMapFiltersExactly |
| **Cross-pipeline** | DoesNotInterfereWithHMACPipeline (HMAC stays deterministic, distinct token shape) |

## Verification — all green

| Check | Result |
|---|---|
| `go build ./...` | ✅ |
| `go test ./internal/secret/...` | ✅ all + 18 new cases |
| `TestRedactGoldenFile` SHA-256 | ✅ **unchanged** (HMAC pipeline untouched) |
| `go test ./...` (18 packages) | ✅ |
| `gofmt -l .` | ✅ |
| `golangci-lint run` | ✅ 0 issues |

## What this PR does NOT include (deliberately)

- **Wiring into `internal/llm/client.go`** — pre-send / post-receive / tool-call-args / streaming-buffer plumbing. Each integration point has subtle gotchas (per the plan's "Wiring into internal/llm/client.go" section) and deserves its own focused review pass with a working chat against a real provider.
- **Recognizer extensions** for Slack tokens, Stripe keys, GitHub PATs, GCP service-account JSON. The plan flags these as must-land-with-G; they're separable from the pipeline core and ship cleanly as a follow-up.
- **Per-profile config flag** (`PromptRedaction.enabled`) and Setup-screen toggle UI. Belongs with the wiring PR so the Setup flow can preview the diff.
- **Streaming partial-token buffer** — a token spanning two SSE chunks needs `UnRedactResponse` on the buffered concatenation, not per-chunk. Plumbing concern, not pipeline concern.

The end-to-end "redact-on-send + un-redact-on-receive" feature lights up once the wiring PR lands. This PR seals the pipeline core contract and proves correctness via tests independently of the integration site.

## Phase 13 substrate state after this lands

```
WS#13.A Tasks UI polish               ✅ shipped (#34)
WS#13.E Cookbook stubs                ✅ shipped (#35)
WS#13.F Slack/Notion/Jira deep-links  ✅ shipped (#33)
WS#13.G applyClassifier prep          ✅ shipped (#37)
WS#13.G RedactForLLM core             🟡 this PR
WS#13.G LLM-client wiring             ⏸ next PR
WS#13.G recognizer extensions         ⏸ next PR
WS#13.B RAG                           plan in memory
WS#13.C Marketplace                   plan in memory
WS#13.D Gmail tool                    plan in memory
WS#13.E aria scrape FFI               plan in memory
```

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)