### PR TITLE
feat(secret): WS#13.G recognizer extensions — Slack / Stripe / GitHub / GCP

### DIFF
--- a/internal/secret/redaction.go
+++ b/internal/secret/redaction.go
@@ -25,6 +25,15 @@ const (
 	CatJWT        Category = "JWT"
 	CatAWSKeyID   Category = "AWS_KEY_ID"
 	CatBearer     Category = "BEARER_TOKEN"
+	// Phase 13 WS#13.G additions — provider-specific token shapes
+	// the security-engineer plan flagged as must-land alongside the
+	// LLM-redaction pipeline. Each one is more specific than the
+	// generic API_KEY catch-all, so they appear earlier in
+	// builtinPatterns to win the sequential-classifier race.
+	CatSlackToken  Category = "SLACK_TOKEN"
+	CatStripeKey   Category = "STRIPE_KEY"
+	CatGitHubToken Category = "GITHUB_TOKEN"
+	CatGCPKey      Category = "GCP_PRIVATE_KEY"
 )
 
 // ErrRedactionUnavailable is returned by Ready() when the redaction subsystem

--- a/internal/secret/redaction_extensions_test.go
+++ b/internal/secret/redaction_extensions_test.go
@@ -1,0 +1,204 @@
+package secret
+
+import (
+	"strings"
+	"testing"
+)
+
+// Phase 13 WS#13.G recognizer-extension tests. The HMAC pipeline's
+// generic infrastructure is covered by redaction_test.go; these tests
+// target the four new provider-specific categories added in WS#13.G:
+//
+//   CatSlackToken   — xoxb-/xoxp-/xoxa-/xoxr-/xoxe.
+//   CatStripeKey    — sk_live_/sk_test_/rk_live_/rk_test_/pk_live_/pk_test_
+//   CatGitHubToken  — ghp_/gho_/ghu_/ghs_/ghr_/github_pat_
+//   CatGCPKey       — -----BEGIN PRIVATE KEY----- … -----END PRIVATE KEY-----
+//
+// All fixture values are split via Go-source string concatenation so
+// GitHub Push Protection and other secret scanners don't flag the
+// repository (the runtime payload is identical to a non-split literal).
+// Same CWE-321 mitigation the existing JWT fixture uses.
+
+// Helper: build a token by joining the prefix to the suffix at runtime.
+// Splitting the literal in source is enough to dodge static scanners
+// that match the surface form `<prefix>-<base64>` etc.
+func split(prefix, body string) string { return prefix + body }
+
+// ---------------------------------------------------------------------------
+// Slack
+// ---------------------------------------------------------------------------
+
+func TestRedactSlack_BotToken(t *testing.T) {
+	t.Parallel()
+	tok := split("xox"+"b", "-1234567890-1234567890-aabbccddeeffaabbccddeeff")
+	in := "SLACK_BOT_TOKEN=" + tok
+	out := Redact(in)
+	if !strings.Contains(out, "<REDACTED:SLACK_TOKEN:") {
+		t.Errorf("Slack bot token not redacted: %q", out)
+	}
+	if strings.Contains(out, tok) {
+		t.Errorf("Slack token plaintext leaked: %q", out)
+	}
+}
+
+func TestRedactSlack_UserToken(t *testing.T) {
+	t.Parallel()
+	tok := split("xox"+"p", "-1111-2222-3333-aabbccddeeff112233445566aabbccdd")
+	out := Redact("user token " + tok)
+	if !strings.Contains(out, "<REDACTED:SLACK_TOKEN:") {
+		t.Errorf("Slack user token not redacted: %q", out)
+	}
+}
+
+func TestRedactSlack_AppToken(t *testing.T) {
+	t.Parallel()
+	tok := split("xox"+"a", "-2-1234567890-1234567890-1234567890-aabbccddeeff")
+	out := Redact("app token " + tok)
+	if !strings.Contains(out, "<REDACTED:SLACK_TOKEN:") {
+		t.Errorf("Slack app token not redacted: %q", out)
+	}
+}
+
+func TestRedactSlack_ConfigurationToken(t *testing.T) {
+	t.Parallel()
+	// xoxe.<rest> uses a dot separator, not a hyphen. Recognizer must
+	// accept both.
+	tok := split("xox"+"e", ".xoxp-1234567890-aabbccdd")
+	out := Redact("config token " + tok)
+	if !strings.Contains(out, "<REDACTED:SLACK_TOKEN:") {
+		t.Errorf("Slack configuration token not redacted: %q", out)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Stripe
+// ---------------------------------------------------------------------------
+
+func TestRedactStripe_LiveSecretKey(t *testing.T) {
+	t.Parallel()
+	tok := split("sk_"+"live_", "AbCdEf1234567890ghIjKlMnOpQrSt")
+	out := Redact("STRIPE_SECRET=" + tok)
+	if !strings.Contains(out, "<REDACTED:STRIPE_KEY:") {
+		t.Errorf("Stripe live key not redacted: %q", out)
+	}
+}
+
+func TestRedactStripe_TestSecretKey(t *testing.T) {
+	t.Parallel()
+	tok := split("sk_"+"test_", "AbCdEf1234567890ghIjKlMnOpQrSt")
+	out := Redact("STRIPE_SECRET_TEST=" + tok)
+	if !strings.Contains(out, "<REDACTED:STRIPE_KEY:") {
+		t.Errorf("Stripe test key not redacted: %q", out)
+	}
+}
+
+func TestRedactStripe_RestrictedKey(t *testing.T) {
+	t.Parallel()
+	tok := split("rk_"+"live_", "AbCdEf1234567890ghIjKlMnOpQrSt")
+	out := Redact(tok + " for analytics")
+	if !strings.Contains(out, "<REDACTED:STRIPE_KEY:") {
+		t.Errorf("Stripe restricted key not redacted: %q", out)
+	}
+}
+
+func TestRedactStripe_PublishableKey(t *testing.T) {
+	t.Parallel()
+	// Publishable keys are technically not secrets, but redacting them
+	// is harmless and keeps the recognizer simple. Documented behaviour.
+	tok := split("pk_"+"live_", "AbCdEf1234567890ghIjKlMnOpQrSt")
+	out := Redact(tok + " embedded in client")
+	if !strings.Contains(out, "<REDACTED:STRIPE_KEY:") {
+		t.Errorf("Stripe publishable key not redacted: %q", out)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GitHub
+// ---------------------------------------------------------------------------
+
+func TestRedactGitHub_ClassicPAT(t *testing.T) {
+	t.Parallel()
+	tok := split("gh"+"p_", "aabbccddeeff1122334455667788990011aabbcc")
+	out := Redact("GITHUB_TOKEN=" + tok)
+	if !strings.Contains(out, "<REDACTED:GITHUB_TOKEN:") {
+		t.Errorf("GitHub classic PAT not redacted: %q", out)
+	}
+}
+
+func TestRedactGitHub_FineGrainedPAT(t *testing.T) {
+	t.Parallel()
+	tok := split("github"+"_pat_", "aabbccddeeff112233445566778899001122334455")
+	out := Redact("fine-grained: " + tok)
+	if !strings.Contains(out, "<REDACTED:GITHUB_TOKEN:") {
+		t.Errorf("GitHub fine-grained PAT not redacted: %q", out)
+	}
+}
+
+func TestRedactGitHub_OAuthAccessToken(t *testing.T) {
+	t.Parallel()
+	for _, prefix := range []string{"gh" + "o_", "gh" + "u_", "gh" + "s_", "gh" + "r_"} {
+		tok := prefix + "aabbccddeeff1122334455667788990011aabbcc"
+		out := Redact("Authorization: token " + tok)
+		if !strings.Contains(out, "<REDACTED:GITHUB_TOKEN:") {
+			t.Errorf("GitHub %s token not redacted: %q", prefix, out)
+		}
+	}
+}
+
+func TestRedactGitHub_PrefersGitHubOverGenericAPIKey(t *testing.T) {
+	t.Parallel()
+	// "Token ghp_…" would also match the bearer-like API_KEY regex
+	// fragment. Ordering in builtinPatterns puts GitHubToken earlier,
+	// so the redacted token must carry GITHUB_TOKEN, not API_KEY.
+	tok := split("gh"+"p_", "aabbccddeeff1122334455667788990011aabbcc")
+	out := Redact("Authorization: Token " + tok)
+	if !strings.Contains(out, "<REDACTED:GITHUB_TOKEN:") {
+		t.Errorf("ordering bug — GITHUB_TOKEN should win: %q", out)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GCP — service-account private keys
+// ---------------------------------------------------------------------------
+
+func TestRedactGCP_PEMBlock(t *testing.T) {
+	t.Parallel()
+	// Realistic shape: header + base64 body + footer. Body is short
+	// and obviously fake — the recognizer requires only the markers.
+	header := "-----BEGIN" + " PRIVATE KEY-----"
+	footer := "-----END" + " PRIVATE KEY-----"
+	in := "service-account credentials:\n" + header +
+		"\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC1vBQfqW3aWzNL" +
+		"\nfakeBase64BodyShortenedForTest\n" + footer + "\nend of file"
+	out := Redact(in)
+	if !strings.Contains(out, "<REDACTED:GCP_PRIVATE_KEY:") {
+		t.Errorf("GCP PEM block not redacted: %q", out)
+	}
+	if strings.Contains(out, "MIIEvQIBADANBgkqhkiG") {
+		t.Errorf("GCP PEM body leaked through: %q", out)
+	}
+	if !strings.Contains(out, "end of file") {
+		t.Errorf("text after PEM block was mangled: %q", out)
+	}
+}
+
+func TestRedactGCP_EscapedNewlines(t *testing.T) {
+	t.Parallel()
+	// JSON-encoded service account creds escape newlines as \n
+	// literals. Recognizer must catch this shape too.
+	header := "-----BEGIN" + " PRIVATE KEY-----"
+	footer := "-----END" + " PRIVATE KEY-----"
+	in := `{"private_key":"` + header +
+		`\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcfakeBase64\n` +
+		footer + `\n"}`
+	out := Redact(in)
+	if !strings.Contains(out, "<REDACTED:GCP_PRIVATE_KEY:") {
+		t.Errorf("GCP escaped-newline PEM not redacted: %q", out)
+	}
+}
+
+// Note: LLM-pipeline coverage of these new categories lands as a
+// follow-up once PR #38 (RedactForLLM core) merges. The HMAC pipeline
+// (Redact / RedactBytes) covers the recognizer correctness here; the
+// LLM pipeline uses the same builtinPatterns table so it picks up the
+// new categories automatically.

--- a/internal/secret/redaction_patterns.go
+++ b/internal/secret/redaction_patterns.go
@@ -52,21 +52,89 @@ var (
 	// Generic high-entropy API key patterns: key/token/secret/password =<value>.
 	apiKeyRe = regexp.MustCompile(
 		`(?i)(?:api[_-]?key|token|secret|password|passwd|pwd)\s*[:=]\s*["']?([A-Za-z0-9\-._~+/!@#$%^&*]{20,})["']?`)
+
+	// Phase 13 WS#13.G — provider-specific recognizers added per the
+	// security-engineer plan. Each is intentionally tighter than the
+	// generic API_KEY catch-all so the redacted token surfaces the
+	// right CATEGORY tag (helps both the audit-lane UI and a human
+	// reviewer noticing "ah, a real Slack bot token leaked").
+
+	// Slack tokens — bot/user/app/legacy. Format documented at
+	// https://api.slack.com/authentication/token-types
+	//   xoxb-<10+>-<10+>-<24+>           bot tokens
+	//   xoxp-<10+>-<10+>-<10+>-<32+>    user tokens
+	//   xoxa-<10+>-<10+>-<10+>-<32+>    workspace app tokens
+	//   xoxr-<10+>-<10+>-<10+>-<32+>    refresh tokens
+	//   xoxe.<rest>                      configuration tokens (newer)
+	slackTokenRe = regexp.MustCompile(
+		`xox[baprse][-.][A-Za-z0-9-]{10,}`)
+
+	// Stripe API keys — restricted (rk_), secret (sk_), publishable
+	// (pk_), test (sk_test_). Stripe's keys are 32-99 chars after the
+	// prefix (varies by environment + restricted-key shape).
+	// https://stripe.com/docs/keys
+	stripeKeyRe = regexp.MustCompile(
+		`(?:sk_live_|sk_test_|rk_live_|rk_test_|pk_live_|pk_test_)[A-Za-z0-9]{24,}`)
+
+	// GitHub tokens — fine-grained personal access tokens (github_pat_),
+	// classic personal access tokens (ghp_), OAuth access tokens (gho_),
+	// user-to-server (ghu_), server-to-server (ghs_), refresh tokens (ghr_).
+	// https://github.blog/2021-04-05-behind-githubs-new-authentication-token-formats/
+	githubTokenRe = regexp.MustCompile(
+		`(?:ghp_|gho_|ghu_|ghs_|ghr_|github_pat_)[A-Za-z0-9_]{20,}`)
+
+	// GCP service-account private keys — appear as JSON values inside
+	// service-account credential files. We match the literal PEM
+	// header/footer that always wraps the private key body, plus
+	// everything between, even when escaped (\n) for JSON. The body
+	// itself is base64 + line breaks; the surrounding markers are the
+	// stable signal.
+	//
+	// Match (?s) so . matches newlines (a real PEM block spans many
+	// lines; escaped JSON form has \n literals so . suffices but we
+	// keep (?s) for robustness across both shapes).
+	gcpPrivateKeyRe = regexp.MustCompile(
+		`(?s)-----BEGIN PRIVATE KEY-----[^-]+-----END PRIVATE KEY-----`)
 )
 
-// builtinPatterns is the ordered classifier table. More specific patterns
-// must come before broader ones — e.g. CreditCard (16 digits, specific BIN
-// prefixes) before Phone (10 digits, generic), and AWSKeyID before APIKey.
+// builtinPatterns is the ordered classifier table. Order is load-bearing
+// because pass 2 of redactInternal runs classifiers sequentially —
+// earlier classifiers' tokenisation shields their region from later
+// classifier regexes. Two ordering rules:
+//
+//  1. Tokens with **unambiguous prefixes** (xoxb-, sk_live_, ghp_,
+//     BEGIN PRIVATE KEY, AKIA…) come first. A Stripe key's digits
+//     would otherwise be redacted as PHONE first, leaving an
+//     `<REDACTED:PHONE:…>` token inside the key that breaks the
+//     Stripe regex's character class.
+//  2. Within each band (provider-specific → AWS → bearer/JWT/API_KEY
+//     → PII) more specific shapes precede broader ones (CC before
+//     Phone within PII; AWS_KEY_ID before generic API_KEY within
+//     credentials).
 var builtinPatterns = []classifier{
-	// PII — specificity descending.
+	// Provider-specific credential shapes — unambiguous prefixes,
+	// must run first so digit runs inside them don't get tagged as
+	// Phone/SSN/CC by the PII band below.
+	{category: CatGCPKey, re: gcpPrivateKeyRe, minLen: 64, maxLen: 8192},
+	{category: CatSlackToken, re: slackTokenRe, minLen: 14, maxLen: 256},
+	{category: CatStripeKey, re: stripeKeyRe, minLen: 27, maxLen: 256},
+	{category: CatGitHubToken, re: githubTokenRe, minLen: 20, maxLen: 256},
+	{category: CatAWSKeyID, re: awsKeyIDRe, minLen: 20, maxLen: 20},
+
+	// Generic credential shapes — JWT and Bearer have distinctive
+	// shape signals (eyJ… for JWT, "Bearer " prefix for Bearer) that
+	// don't overlap with PII; API_KEY is the catch-all and must come
+	// last among credential matchers.
+	{category: CatJWT, re: jwtRe, minLen: 20, maxLen: 4096},
+	{category: CatBearer, re: bearerRe, minLen: 20, maxLen: 4096},
+	{category: CatAPIKey, re: apiKeyRe, minLen: 20, maxLen: 512},
+
+	// PII — specificity descending. Runs LAST among the regex bands
+	// so digit-only PII patterns (Phone, SSN, CC) don't carve into
+	// provider-specific credentials whose values may contain long
+	// digit runs.
 	{category: CatEmail, re: emailRe, negative: docsEmailRe, minLen: 6, maxLen: 254},
 	{category: CatCreditCard, re: ccRe, negative: testCCRe, minLen: 13, maxLen: 19},
 	{category: CatSSN, re: ssnRe, negative: invalidSSNRe, minLen: 9, maxLen: 11},
 	{category: CatPhone, re: phoneRe, minLen: 10, maxLen: 20},
-
-	// Credentials — order matters: AWS before generic API_KEY.
-	{category: CatAWSKeyID, re: awsKeyIDRe, minLen: 20, maxLen: 20},
-	{category: CatJWT, re: jwtRe, minLen: 20, maxLen: 4096},
-	{category: CatBearer, re: bearerRe, minLen: 20, maxLen: 4096},
-	{category: CatAPIKey, re: apiKeyRe, minLen: 20, maxLen: 512},
 }

--- a/internal/secret/redaction_test.go
+++ b/internal/secret/redaction_test.go
@@ -13,7 +13,16 @@ import (
 // GOLDEN_VERSION must be bumped whenever redaction_patterns.go changes in a
 // way that alters the golden fixture output. This forces an explicit reviewer
 // sign-off that the pattern change is intentional.
-const GOLDEN_VERSION = 1
+//
+// Version 2 (Phase 13 WS#13.G): adds CatGCPKey / CatSlackToken /
+// CatStripeKey / CatGitHubToken recognizers ahead of the generic
+// CatAPIKey, and reorders builtinPatterns so provider-specific
+// shapes run before the PII band (preventing a 10-digit run inside
+// a Stripe key from being tagged as PHONE first). The golden
+// fixture's `Authorization: Token ghp_…` line now redacts as
+// <REDACTED:GITHUB_TOKEN:…> instead of passing through, and the
+// per-line token shape changes wherever new categories now apply.
+const GOLDEN_VERSION = 2
 
 // expectedGoldenSHA256 is the SHA-256 digest (hex, lowercase) of the redacted
 // output produced from testdata/redaction_golden.txt with the test HMAC key
@@ -25,7 +34,7 @@ const GOLDEN_VERSION = 1
 //
 // IMPORTANT: If this digest changes without a corresponding GOLDEN_VERSION
 // bump, the test fails loudly and the coder must re-review all patterns.
-const expectedGoldenSHA256 = "0e169761a670c0af18f576dcf1d6a7d8e272de2ce756af99418e57a58c771dae"
+const expectedGoldenSHA256 = "156e8340e470aa16f14658fed439b9a8379cab6d6190a0981217283995bb8334"
 
 // ---------------------------------------------------------------------------
 // TestMain — install deterministic HMAC key before any test runs.
@@ -124,8 +133,12 @@ func TestRedactDeterministic(t *testing.T) {
 			"SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
 			category: CatJWT},
 
-		// Bearer token (non-JWT)
-		{name: "bearer-opaque", input: "Authorization: Bearer ghp_16C7e42F292c6912E7710c838347Ae178B4a", category: CatBearer},
+		// Bearer token (non-JWT, non-provider-specific). Originally
+		// used a `ghp_…` GitHub PAT here as a generic placeholder, but
+		// the Phase 13 WS#13.G GITHUB_TOKEN recognizer now correctly
+		// picks that prefix up — so use a base64-shaped opaque value
+		// that maps cleanly to the generic Bearer category.
+		{name: "bearer-opaque", input: "Authorization: Bearer YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXowMTIzNDU2Nzg5", category: CatBearer},
 
 		// Generic API key
 		{name: "api-key-header", input: "X-API-Key: sk-abc123def456ghi789jkl012mno345pqr678", category: CatAPIKey},


### PR DESCRIPTION
## Summary

Phase 13 WS#13.G recognizer extensions — adds four provider-specific token recognizers the security-engineer plan flagged as must-land alongside the LLM-redaction pipeline. Each is more specific than the generic `API_KEY` catch-all so the redacted token carries the right `CATEGORY` tag.

Independent of PR #38 (the `RedactForLLM` core). LLM-pipeline coverage of these new categories lands as a tiny follow-up once #38 merges.

## New categories

| Category | Pattern (high-level) | Captures |
|---|---|---|
| `CatSlackToken` | `xox[baprse][-.][A-Za-z0-9-]{10,}` | bot/user/app/refresh/configuration tokens |
| `CatStripeKey` | `(?:sk_live_\|sk_test_\|rk_live_\|rk_test_\|pk_live_\|pk_test_)[A-Za-z0-9]{24,}` | secret/restricted/publishable, live + test envs |
| `CatGitHubToken` | `(?:ghp_\|gho_\|ghu_\|ghs_\|ghr_\|github_pat_)[A-Za-z0-9_]{20,}` | classic + fine-grained PATs, OAuth/u2s/s2s/refresh |
| `CatGCPKey` | `(?s)-----BEGIN PRIVATE KEY-----[^-]+-----END PRIVATE KEY-----` | PEM block + JSON-escaped `\n` form |

## `builtinPatterns` reordered

Old order (PII first, then credentials) silently broke the new recognizers: a Stripe live-key like `sk_live_AbCdEf1234567890…` contains a 10-digit run that Phone would tokenize first, leaving a `<REDACTED:PHONE:…>` token inside the key that breaks the Stripe regex's character class.

New order:
```
1. Provider-specific:  GCP → Slack → Stripe → GitHub → AWS_KEY_ID
2. Generic credentials: JWT → Bearer → API_KEY
3. PII:                 Email → CC → SSN → Phone
```

Provider tokens have unambiguous prefixes — they can't accidentally match a CC or phone, so running them first is safe and necessary.

## Tests — 13 new cases

| Group | Cases |
|---|---|
| Slack | BotToken · UserToken · AppToken · ConfigurationToken (xoxe.) |
| Stripe | LiveSecretKey · TestSecretKey · RestrictedKey · PublishableKey |
| GitHub | ClassicPAT · FineGrainedPAT · OAuthAccessToken (4 prefixes) · PrefersGitHubOverGenericAPIKey |
| GCP | PEMBlock · EscapedNewlines (JSON-escaped form) |

All fixture values are split via Go-source string concatenation (CWE-321 mitigation) so GitHub Push Protection and other secret scanners don't flag the repository — same technique the existing JWT fixture uses.

## Golden + test fixture updates

| | |
|---|---|
| `GOLDEN_VERSION` | `1 → 2` (per the explicit reviewer-signoff convention) |
| `expectedGoldenSHA256` | `0e169761…` → `156e8340…` |
| `TestRedactDeterministic.bearer-opaque` | fixture changed from a `ghp_…` value (which now correctly tags as `GITHUB_TOKEN`) to a base64-shaped opaque value that maps to the generic Bearer category as the test originally intended |

The golden-fixture line `Authorization: Token ghp_…` now redacts as `<REDACTED:GITHUB_TOKEN:…>` instead of passing through. The reorder also shifts a couple of other line outputs.

## Verification

| Check | Result |
|---|---|
| `go build ./...` | ✅ |
| `go test ./internal/secret/...` | ✅ all suites + 13 new cases |
| `TestRedactGoldenFile` | ✅ passes new SHA |
| `go test ./...` (18 packages) | ✅ |
| `gofmt -l .` | ✅ |
| `golangci-lint run` | ✅ 0 issues |

## Phase 13 substrate state after this lands

```
WS#13.A Tasks UI polish               ✅ shipped
WS#13.E Cookbook stubs                ✅ shipped
WS#13.F Slack/Notion/Jira deep-links  ✅ shipped
WS#13.G applyClassifier prep          ✅ shipped (#37)
WS#13.G RedactForLLM core             🟡 #38 open
WS#13.G recognizer extensions         🟡 this PR
WS#13.G LLM-client wiring             ⏸ next slice
WS#13.B RAG / sqlite-vec              plan in claude-flow memory
WS#13.C Marketplace                   plan in claude-flow memory
WS#13.D Gmail tool                    plan in claude-flow memory
WS#13.E aria scrape FFI               plan in claude-flow memory
```

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)