### PR TITLE
feat(storage): WS#13.B RAG schema — rag_embeddings + rag_state tables

### DIFF
--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -65,6 +65,10 @@ func Open(dbPath string) (*DB, error) {
 		_ = sqlDB.Close()
 		return nil, fmt.Errorf("storage.Open migrateActionReceiptsSaasSplit: %w", err)
 	}
+	if err := d.migrateRAGEmbeddings(); err != nil {
+		_ = sqlDB.Close()
+		return nil, fmt.Errorf("storage.Open migrateRAGEmbeddings: %w", err)
+	}
 	return d, nil
 }
 
@@ -324,6 +328,47 @@ func (d *DB) migrateActionReceiptsSaasSplit() error {
 	return nil
 }
 
+// migrateRAGEmbeddings is the Phase 13 WS#13.B schema migration that
+// creates the durable side-table for semantic-search embeddings plus
+// the rag_state cursor table. Both are CREATE TABLE IF NOT EXISTS so
+// the base migrate() statement above ALSO creates them on a fresh DB
+// — this function exists so an existing v0.6.0 DB upgrades cleanly
+// without dropping data.
+//
+// Idempotency: every statement is IF NOT EXISTS. Re-running on an
+// already-migrated DB is a no-op. The function is safe to call from
+// any number of concurrent storage.Open instances thanks to SQLite's
+// single-writer pool, but in practice Open is serialized.
+func (d *DB) migrateRAGEmbeddings() error {
+	stmts := []string{
+		`CREATE TABLE IF NOT EXISTS rag_embeddings (
+			id           INTEGER PRIMARY KEY AUTOINCREMENT,
+			source       TEXT    NOT NULL,
+			source_id    TEXT    NOT NULL,
+			session_id   TEXT,
+			content_hash TEXT    NOT NULL,
+			text         TEXT    NOT NULL,
+			model        TEXT    NOT NULL,
+			dim          INTEGER NOT NULL,
+			vector       BLOB    NOT NULL,
+			created_at   INTEGER NOT NULL,
+			UNIQUE(source, source_id, model)
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_rag_session ON rag_embeddings(session_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_rag_hash    ON rag_embeddings(content_hash)`,
+		`CREATE TABLE IF NOT EXISTS rag_state (
+			key   TEXT PRIMARY KEY,
+			value TEXT NOT NULL
+		)`,
+	}
+	for _, s := range stmts {
+		if _, err := d.db.Exec(s); err != nil {
+			return fmt.Errorf("migrateRAGEmbeddings: %w", err)
+		}
+	}
+	return nil
+}
+
 // Close releases the underlying database connection.
 func (d *DB) Close() error {
 	return d.db.Close()
@@ -501,6 +546,48 @@ CREATE TABLE IF NOT EXISTS action_receipts (
 );
 CREATE INDEX IF NOT EXISTS idx_action_receipts_task_created
     ON action_receipts(task_id, created_at);
+
+-- ---------------------------------------------------------------------------
+-- Phase 13 WS#13.B — RAG embeddings (durable side-table for semantic search)
+-- source:        'message' | 'step' | 'receipt' — what produced the entry
+-- source_id:     foreign-ish id into the source table (free-form, not enforced
+--                via FK because deletes propagate via tombstones, not cascades)
+-- session_id:    optional scoping for the search ACL filter
+-- content_hash:  SHA-256 hex of the text column; lets re-indexing be idempotent
+-- text:          the indexed string (already HMAC-redacted before write so a
+--                vector-similarity attack cannot reconstruct secrets — see
+--                Phase 13 WS#13.G threat note I5)
+-- model:         embedding model id (e.g. regolo:bge-small-en-v1.5); a model
+--                swap re-indexes lazily because UNIQUE(source,source_id,model)
+--                rejects collisions per-model
+-- dim:           embedding dimensionality (sanity check on writes)
+-- vector:        float32 little-endian packed BLOB (4*dim bytes)
+-- created_at:    unix seconds, indexed implicitly via PK insertion order
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS rag_embeddings (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    source       TEXT    NOT NULL,
+    source_id    TEXT    NOT NULL,
+    session_id   TEXT,
+    content_hash TEXT    NOT NULL,
+    text         TEXT    NOT NULL,
+    model        TEXT    NOT NULL,
+    dim          INTEGER NOT NULL,
+    vector       BLOB    NOT NULL,
+    created_at   INTEGER NOT NULL,
+    UNIQUE(source, source_id, model)
+);
+CREATE INDEX IF NOT EXISTS idx_rag_session ON rag_embeddings(session_id);
+CREATE INDEX IF NOT EXISTS idx_rag_hash    ON rag_embeddings(content_hash);
+
+-- rag_state holds a single-row cursor that the embedder watcher uses to
+-- replay missed events after a crash. Schema is "key/value" so we can
+-- accrete future fields (last_indexed_event_id, last_indexed_message_id,
+-- last_purged_at) without bumping a migration each time.
+CREATE TABLE IF NOT EXISTS rag_state (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
 `
 	_, err := d.db.Exec(schema)
 	if err != nil {

--- a/internal/storage/rag_schema_test.go
+++ b/internal/storage/rag_schema_test.go
@@ -1,0 +1,241 @@
+package storage
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// Phase 13 WS#13.B — schema migration tests for rag_embeddings + rag_state.
+// The migration is the substrate; the embedder/index/search work lands in a
+// follow-up. Tests cover three shapes:
+//
+//   1. Fresh DB: tables exist with the expected columns after Open().
+//   2. Idempotency: re-running migrateRAGEmbeddings on a populated DB is
+//      a no-op (no duplicate rows, no constraint surprises).
+//   3. Upgrade path: simulate a v0.6.0-shape DB where the rag tables don't
+//      exist yet, then call migrateRAGEmbeddings explicitly — it must
+//      create them without disturbing the existing data.
+
+// expectedRAGEmbeddingsCols mirrors db.go schema literal exactly.
+var expectedRAGEmbeddingsCols = map[string]bool{
+	"id":           false,
+	"source":       false,
+	"source_id":    false,
+	"session_id":   false,
+	"content_hash": false,
+	"text":         false,
+	"model":        false,
+	"dim":          false,
+	"vector":       false,
+	"created_at":   false,
+}
+
+func tableExists(t *testing.T, db *DB, name string) bool {
+	t.Helper()
+	var count int
+	err := db.db.QueryRow(
+		`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=?`,
+		name,
+	).Scan(&count)
+	if err != nil {
+		t.Fatalf("tableExists query: %v", err)
+	}
+	return count == 1
+}
+
+func indexExists(t *testing.T, db *DB, name string) bool {
+	t.Helper()
+	var count int
+	err := db.db.QueryRow(
+		`SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name=?`,
+		name,
+	).Scan(&count)
+	if err != nil {
+		t.Fatalf("indexExists query: %v", err)
+	}
+	return count == 1
+}
+
+func TestRAGEmbeddings_FreshDB(t *testing.T) {
+	db := openTestDB(t)
+
+	if !tableExists(t, db, "rag_embeddings") {
+		t.Fatal("rag_embeddings table missing on fresh DB")
+	}
+	if !tableExists(t, db, "rag_state") {
+		t.Fatal("rag_state table missing on fresh DB")
+	}
+	if !indexExists(t, db, "idx_rag_session") {
+		t.Error("idx_rag_session index missing")
+	}
+	if !indexExists(t, db, "idx_rag_hash") {
+		t.Error("idx_rag_hash index missing")
+	}
+
+	rows, err := db.db.Query(`PRAGMA table_info(rag_embeddings)`)
+	if err != nil {
+		t.Fatalf("PRAGMA table_info: %v", err)
+	}
+	defer rows.Close()
+	got := map[string]bool{}
+	for rows.Next() {
+		var cid int
+		var name, ctype string
+		var notnull, pk int
+		var dflt any
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		got[name] = true
+	}
+	for col := range expectedRAGEmbeddingsCols {
+		if !got[col] {
+			t.Errorf("rag_embeddings missing column %q", col)
+		}
+	}
+}
+
+func TestRAGEmbeddings_Idempotent(t *testing.T) {
+	db := openTestDB(t)
+
+	if _, err := db.db.Exec(
+		`INSERT INTO rag_embeddings
+		 (source, source_id, content_hash, text, model, dim, vector, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		"test", "id-1", "hash-1", "hello", "test-model", 4,
+		[]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 1700000000,
+	); err != nil {
+		t.Fatalf("seed insert: %v", err)
+	}
+	if _, err := db.db.Exec(
+		`INSERT INTO rag_state (key, value) VALUES (?, ?)`,
+		"last_indexed_event_id", "42",
+	); err != nil {
+		t.Fatalf("seed rag_state: %v", err)
+	}
+
+	// Re-run the migration in isolation. Must not error and must not
+	// touch existing rows.
+	for i := 0; i < 3; i++ {
+		if err := db.migrateRAGEmbeddings(); err != nil {
+			t.Fatalf("migrateRAGEmbeddings re-run #%d: %v", i, err)
+		}
+	}
+
+	var n int
+	if err := db.db.QueryRow(`SELECT COUNT(*) FROM rag_embeddings`).Scan(&n); err != nil {
+		t.Fatalf("count rag_embeddings: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("rag_embeddings row count = %d, want 1 (migration ate or duplicated rows)", n)
+	}
+
+	var v string
+	if err := db.db.QueryRow(
+		`SELECT value FROM rag_state WHERE key='last_indexed_event_id'`,
+	).Scan(&v); err != nil {
+		t.Fatalf("read rag_state: %v", err)
+	}
+	if v != "42" {
+		t.Errorf("rag_state value = %q, want %q", v, "42")
+	}
+}
+
+func TestRAGEmbeddings_UpgradePath(t *testing.T) {
+	// Simulate a v0.6.0-shape DB by opening, dropping the rag tables,
+	// then calling migrateRAGEmbeddings — the path an existing user's
+	// DB takes when they upgrade to the WS#13.B build.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "upgrade.db")
+	db, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	// Seed an existing session so we can verify the migration doesn't
+	// touch unrelated data.
+	s, err := db.CreateSession("test-model")
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	// Drop the rag tables to mimic a pre-WS#13.B DB.
+	for _, ddl := range []string{
+		`DROP INDEX IF EXISTS idx_rag_session`,
+		`DROP INDEX IF EXISTS idx_rag_hash`,
+		`DROP TABLE IF EXISTS rag_embeddings`,
+		`DROP TABLE IF EXISTS rag_state`,
+	} {
+		if _, err := db.db.Exec(ddl); err != nil {
+			t.Fatalf("simulate v0.6.0 (%s): %v", ddl, err)
+		}
+	}
+	if tableExists(t, db, "rag_embeddings") {
+		t.Fatal("setup: rag_embeddings still exists after DROP")
+	}
+
+	// Run only the upgrade migration (not the full migrate()).
+	if err := db.migrateRAGEmbeddings(); err != nil {
+		t.Fatalf("migrateRAGEmbeddings upgrade: %v", err)
+	}
+
+	if !tableExists(t, db, "rag_embeddings") {
+		t.Error("rag_embeddings not created on upgrade")
+	}
+	if !tableExists(t, db, "rag_state") {
+		t.Error("rag_state not created on upgrade")
+	}
+	if !indexExists(t, db, "idx_rag_session") {
+		t.Error("idx_rag_session not created on upgrade")
+	}
+	if !indexExists(t, db, "idx_rag_hash") {
+		t.Error("idx_rag_hash not created on upgrade")
+	}
+
+	// Pre-existing session must survive the upgrade.
+	got, err := db.GetSession(s.ID)
+	if err != nil {
+		t.Fatalf("GetSession after upgrade: %v", err)
+	}
+	if got.ID != s.ID {
+		t.Errorf("session ID changed: %q vs %q", got.ID, s.ID)
+	}
+
+	// Migration must satisfy UNIQUE(source, source_id, model).
+	if _, err := db.db.Exec(
+		`INSERT INTO rag_embeddings
+		 (source, source_id, content_hash, text, model, dim, vector, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		"msg", "abc", "h", "hi", "m", 1, []byte{0, 0, 0, 0}, 1,
+	); err != nil {
+		t.Fatalf("post-upgrade insert: %v", err)
+	}
+	if _, err := db.db.Exec(
+		`INSERT INTO rag_embeddings
+		 (source, source_id, content_hash, text, model, dim, vector, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		"msg", "abc", "h", "hi", "m", 1, []byte{0, 0, 0, 0}, 2,
+	); err == nil {
+		t.Error("UNIQUE(source,source_id,model) constraint not enforced after upgrade")
+	}
+
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Reopen — full Open() path runs migrateRAGEmbeddings again on a
+	// now-populated DB; must succeed without disturbing the row.
+	db2, err := Open(path)
+	if err != nil {
+		t.Fatalf("Reopen: %v", err)
+	}
+	t.Cleanup(func() { _ = db2.Close() })
+
+	var n int
+	if err := db2.db.QueryRow(`SELECT COUNT(*) FROM rag_embeddings`).Scan(&n); err != nil {
+		t.Fatalf("count after reopen: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("rag_embeddings rows after reopen = %d, want 1", n)
+	}
+}


### PR DESCRIPTION
## Summary

WS#13.B substrate slice — adds the durable schema the RAG indexer will write into, no embedder/watcher/search wired yet so this stays a sealed migration that can land independently.

- `rag_embeddings` keyed by `UNIQUE(source, source_id, model)` so the same content can re-index under a different embedding model without colliding
- `rag_state` is a key/value cursor table the watcher uses to replay missed events after a crash
- Migration is idempotent (`CREATE TABLE IF NOT EXISTS` everywhere) and runs in the `Open()` chain right after the saas-split migration
- Embedder + index wrapper + watcher + search + HTTP endpoint + chat-loop integration land in the follow-up; this PR is just the substrate

## Schema shape

```
rag_embeddings(
  id, source, source_id, session_id, content_hash,
  text, model, dim, vector BLOB, created_at,
  UNIQUE(source, source_id, model)
)
idx_rag_session ON (session_id)   -- per-session purges
idx_rag_hash    ON (content_hash) -- dedup before re-embedding
```

`vector` is float32 little-endian packed (4×dim bytes); `dim` is recorded for sanity-check on writes. Sticking with a plain BLOB column keeps the migration vec-extension-free — a `sqlite-vec` virtual table can be layered on top later without a schema change to this row.

## Test plan

- [x] `go test ./internal/storage/ -v -run TestRAGEmbeddings` — 3 new tests pass
  - `TestRAGEmbeddings_FreshDB` — tables + indexes + columns present after `Open()`
  - `TestRAGEmbeddings_Idempotent` — `migrateRAGEmbeddings()` runs 3× on a populated DB without losing rows
  - `TestRAGEmbeddings_UpgradePath` — simulates a v0.6.0 DB by dropping the rag tables, runs the migration, verifies pre-existing session rows survive, UNIQUE constraint enforced, reopen path works
- [x] `go test ./internal/storage/` — full package green (19 tests)
- [x] `go vet ./internal/storage/` — no issues
- [x] `golangci-lint run ./internal/storage/` — 0 issues

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)