### PR TITLE
feat(rag): WS#13.B codec + storage helpers — vector BLOB + typed CRUD

### DIFF
--- a/internal/rag/codec.go
+++ b/internal/rag/codec.go
@@ -1,0 +1,117 @@
+// Package rag is the Phase 13 WS#13.B retrieval-augmented-generation
+// substrate. The schema lives in internal/storage (rag_embeddings +
+// rag_state); this package owns the small primitives that sit on top —
+// vector BLOB encoding, content-hash gating, the embedder interface,
+// and (in follow-up slices) the index wrapper, watcher, and search.
+//
+// Design choices documented at the package level so future slices
+// don't have to re-derive them:
+//
+//  1. Vectors are stored as packed little-endian float32 (4 bytes per
+//     dim). SQLite BLOBs are byte-addressable; the pack/unpack pair
+//     is symmetrical and round-trips byte-for-byte. Choosing
+//     little-endian matches the dominant CPU architecture for
+//     desktop deployment (x86_64 + aarch64 macOS) so the BLOB can
+//     be mmap'd into a tensor library without a byte-swap pass when
+//     we eventually layer sqlite-vec on top.
+//
+//  2. Content hashes are sha256 hex of the un-trimmed input string.
+//     Identical text → identical hash → idx_rag_hash hits and we
+//     skip a round-trip to the embedder. The hash is NOT a security
+//     primitive (no HMAC); it's a dedup key.
+//
+//  3. The embedder is an interface (Embedder.Embed) so tests can
+//     inject a fake without standing up an HTTP server, and
+//     providers other than the OpenAI-compatible /v1/embeddings
+//     shape can be added behind the same interface.
+package rag
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"math"
+)
+
+// ErrDimMismatch reports that a vector's length didn't match the
+// caller-asserted dimensionality. Returned by UnpackVector when the
+// BLOB length is not exactly 4*dim, and by validation paths that
+// compare against the rag_embeddings.dim column.
+var ErrDimMismatch = errors.New("rag: vector dimension mismatch")
+
+// ErrEmptyVector reports that PackVector was handed a zero-length
+// slice. Empty vectors aren't legal in rag_embeddings (the schema
+// requires NOT NULL on dim and vector); this surfaces the misuse at
+// the encode boundary instead of the SQLite write site.
+var ErrEmptyVector = errors.New("rag: empty vector")
+
+// PackVector encodes a float32 slice into little-endian bytes
+// suitable for the rag_embeddings.vector BLOB column. Length is
+// exactly 4*len(v). NaN and ±Inf are preserved bit-for-bit (we use
+// math.Float32bits, not a comparison-based encoder).
+func PackVector(v []float32) ([]byte, error) {
+	if len(v) == 0 {
+		return nil, ErrEmptyVector
+	}
+	out := make([]byte, 4*len(v))
+	for i, f := range v {
+		binary.LittleEndian.PutUint32(out[i*4:], math.Float32bits(f))
+	}
+	return out, nil
+}
+
+// UnpackVector decodes a 4*dim byte BLOB back into a float32 slice.
+// Returns ErrDimMismatch when len(b) != 4*dim — callers always know
+// the expected dim from the rag_embeddings row, so a length mismatch
+// indicates corruption (or a model-swap that didn't cascade).
+func UnpackVector(b []byte, dim int) ([]float32, error) {
+	if dim <= 0 {
+		return nil, fmt.Errorf("%w: dim must be positive, got %d", ErrDimMismatch, dim)
+	}
+	if len(b) != 4*dim {
+		return nil, fmt.Errorf("%w: blob len = %d, want %d", ErrDimMismatch, len(b), 4*dim)
+	}
+	out := make([]float32, dim)
+	for i := 0; i < dim; i++ {
+		out[i] = math.Float32frombits(binary.LittleEndian.Uint32(b[i*4:]))
+	}
+	return out, nil
+}
+
+// ContentHash returns the sha256 hex digest of text, used as the
+// dedup key in rag_embeddings.content_hash. The hash is computed
+// over the raw bytes — callers that want pre-trim normalisation
+// should normalise before calling this.
+func ContentHash(text string) string {
+	sum := sha256.Sum256([]byte(text))
+	return hex.EncodeToString(sum[:])
+}
+
+// CosineSimilarity returns the cosine similarity of a and b. Returns
+// 0 when either vector is all-zero (the alternative — NaN from a 0/0
+// — propagates badly through ranking code). Returns ErrDimMismatch
+// when the lengths differ.
+//
+// Used by the next-slice search path; landed here alongside the codec
+// so the package's vector primitives form a coherent unit.
+func CosineSimilarity(a, b []float32) (float32, error) {
+	if len(a) != len(b) {
+		return 0, fmt.Errorf("%w: a=%d b=%d", ErrDimMismatch, len(a), len(b))
+	}
+	if len(a) == 0 {
+		return 0, ErrEmptyVector
+	}
+	var dot, na, nb float64
+	for i := range a {
+		x, y := float64(a[i]), float64(b[i])
+		dot += x * y
+		na += x * x
+		nb += y * y
+	}
+	if na == 0 || nb == 0 {
+		return 0, nil
+	}
+	return float32(dot / (math.Sqrt(na) * math.Sqrt(nb))), nil
+}

--- a/internal/rag/codec_test.go
+++ b/internal/rag/codec_test.go
@@ -1,0 +1,224 @@
+package rag
+
+import (
+	"bytes"
+	"errors"
+	"math"
+	"testing"
+)
+
+// Phase 13 WS#13.B — codec primitives. Covers the BLOB pack/unpack
+// round-trip, content-hash determinism, and cosine similarity edge
+// cases. The next slice (storage helpers) builds on these guarantees.
+
+func TestPackVector_RoundTrip(t *testing.T) {
+	t.Parallel()
+	in := []float32{0.0, 1.0, -1.0, 0.5, -0.5, 1e-6, 1e6, math.MaxFloat32, math.SmallestNonzeroFloat32}
+	b, err := PackVector(in)
+	if err != nil {
+		t.Fatalf("PackVector: %v", err)
+	}
+	if len(b) != 4*len(in) {
+		t.Errorf("len = %d, want %d", len(b), 4*len(in))
+	}
+	out, err := UnpackVector(b, len(in))
+	if err != nil {
+		t.Fatalf("UnpackVector: %v", err)
+	}
+	if len(out) != len(in) {
+		t.Fatalf("decoded len = %d, want %d", len(out), len(in))
+	}
+	for i := range in {
+		if math.Float32bits(out[i]) != math.Float32bits(in[i]) {
+			t.Errorf("[%d] = %v, want %v (bits %x vs %x)",
+				i, out[i], in[i],
+				math.Float32bits(out[i]), math.Float32bits(in[i]))
+		}
+	}
+}
+
+func TestPackVector_PreservesSpecialValues(t *testing.T) {
+	t.Parallel()
+	// Construct -0.0 via bit-pattern — Go folds the literal -0.0 to
+	// +0.0 at parse time, so we have to materialise the sign bit
+	// explicitly to test it round-trips through PackVector.
+	negZero := math.Float32frombits(1 << 31)
+	specials := []float32{
+		float32(math.NaN()),
+		float32(math.Inf(1)),
+		float32(math.Inf(-1)),
+		0.0,
+		negZero,
+	}
+	b, err := PackVector(specials)
+	if err != nil {
+		t.Fatalf("PackVector: %v", err)
+	}
+	out, err := UnpackVector(b, len(specials))
+	if err != nil {
+		t.Fatalf("UnpackVector: %v", err)
+	}
+	// NaN: compare bit pattern (Float32 NaN comparisons are always false).
+	if math.Float32bits(out[0]) != math.Float32bits(specials[0]) {
+		t.Errorf("NaN bits not preserved")
+	}
+	// Inf comparisons are well-defined.
+	if !math.IsInf(float64(out[1]), 1) {
+		t.Errorf("+Inf not preserved: %v", out[1])
+	}
+	if !math.IsInf(float64(out[2]), -1) {
+		t.Errorf("-Inf not preserved: %v", out[2])
+	}
+	// Signed zero: compare bits (==0 ignores sign).
+	if math.Float32bits(out[4]) != math.Float32bits(specials[4]) {
+		t.Errorf("-0.0 sign bit lost")
+	}
+}
+
+func TestPackVector_LittleEndian(t *testing.T) {
+	t.Parallel()
+	// 1.0 in IEEE 754 binary32 = 0x3F800000 = LE bytes 00 00 80 3F.
+	b, err := PackVector([]float32{1.0})
+	if err != nil {
+		t.Fatalf("PackVector: %v", err)
+	}
+	want := []byte{0x00, 0x00, 0x80, 0x3F}
+	if !bytes.Equal(b, want) {
+		t.Errorf("LE encoding of 1.0 = %x, want %x", b, want)
+	}
+}
+
+func TestPackVector_EmptyError(t *testing.T) {
+	t.Parallel()
+	_, err := PackVector(nil)
+	if !errors.Is(err, ErrEmptyVector) {
+		t.Errorf("err = %v, want ErrEmptyVector", err)
+	}
+	_, err = PackVector([]float32{})
+	if !errors.Is(err, ErrEmptyVector) {
+		t.Errorf("err = %v, want ErrEmptyVector", err)
+	}
+}
+
+func TestUnpackVector_DimMismatch(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		blob []byte
+		dim  int
+	}{
+		{"short_blob", []byte{0, 0, 0}, 1},
+		{"long_blob", []byte{0, 0, 0, 0, 0}, 1},
+		{"zero_dim", []byte{0, 0, 0, 0}, 0},
+		{"negative_dim", []byte{0, 0, 0, 0}, -1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := UnpackVector(tc.blob, tc.dim)
+			if !errors.Is(err, ErrDimMismatch) {
+				t.Errorf("err = %v, want ErrDimMismatch", err)
+			}
+		})
+	}
+}
+
+func TestContentHash_Deterministic(t *testing.T) {
+	t.Parallel()
+	a := ContentHash("hello world")
+	b := ContentHash("hello world")
+	if a != b {
+		t.Errorf("hash drift: %q != %q", a, b)
+	}
+	if len(a) != 64 {
+		t.Errorf("len = %d, want 64 (sha256 hex)", len(a))
+	}
+	// Known sha256 of "hello world" — pinning the exact hash so we
+	// detect accidental normalisation drift.
+	const want = "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+	if a != want {
+		t.Errorf("hash = %q, want %q", a, want)
+	}
+}
+
+func TestContentHash_Distinguishes(t *testing.T) {
+	t.Parallel()
+	if ContentHash("a") == ContentHash("b") {
+		t.Error("distinct inputs collided")
+	}
+	// Whitespace matters — we hash raw bytes.
+	if ContentHash("hello") == ContentHash(" hello") {
+		t.Error("leading whitespace ignored — hash should be raw")
+	}
+}
+
+func TestContentHash_Empty(t *testing.T) {
+	t.Parallel()
+	// sha256("") is well-known; lock it in so the empty case is documented.
+	const want = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	if got := ContentHash(""); got != want {
+		t.Errorf("empty hash = %q, want %q", got, want)
+	}
+}
+
+func TestCosineSimilarity_Cases(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		a, b []float32
+		want float32
+		eps  float32
+	}{
+		{"identical", []float32{1, 0, 0}, []float32{1, 0, 0}, 1.0, 1e-6},
+		{"orthogonal", []float32{1, 0}, []float32{0, 1}, 0.0, 1e-6},
+		{"opposite", []float32{1, 0}, []float32{-1, 0}, -1.0, 1e-6},
+		{"scaled", []float32{2, 0}, []float32{5, 0}, 1.0, 1e-6},
+		{"45deg", []float32{1, 0}, []float32{1, 1}, 0.7071, 1e-3},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := CosineSimilarity(tc.a, tc.b)
+			if err != nil {
+				t.Fatalf("err = %v", err)
+			}
+			diff := got - tc.want
+			if diff < 0 {
+				diff = -diff
+			}
+			if diff > tc.eps {
+				t.Errorf("got %v, want %v ± %v", got, tc.want, tc.eps)
+			}
+		})
+	}
+}
+
+func TestCosineSimilarity_ZeroVector(t *testing.T) {
+	t.Parallel()
+	// Either side zero must return 0, not NaN — ranking code can't
+	// recover from NaN gracefully.
+	got, err := CosineSimilarity([]float32{0, 0, 0}, []float32{1, 1, 1})
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if got != 0 {
+		t.Errorf("zero vector → %v, want 0", got)
+	}
+	got, err = CosineSimilarity([]float32{1, 1}, []float32{0, 0})
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if got != 0 {
+		t.Errorf("zero vector (b) → %v, want 0", got)
+	}
+}
+
+func TestCosineSimilarity_Errors(t *testing.T) {
+	t.Parallel()
+	_, err := CosineSimilarity([]float32{1, 0}, []float32{1, 0, 0})
+	if !errors.Is(err, ErrDimMismatch) {
+		t.Errorf("dim mismatch err = %v, want ErrDimMismatch", err)
+	}
+	_, err = CosineSimilarity([]float32{}, []float32{})
+	if !errors.Is(err, ErrEmptyVector) {
+		t.Errorf("empty err = %v, want ErrEmptyVector", err)
+	}
+}

--- a/internal/storage/rag.go
+++ b/internal/storage/rag.go
@@ -1,0 +1,207 @@
+package storage
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// Phase 13 WS#13.B — storage helpers for the rag_embeddings + rag_state
+// tables (schema in db.go's migrate() + migrateRAGEmbeddings()).
+//
+// This file owns the typed CRUD surface the rag package will call. The
+// rag package stays free of database/sql so codec/embedder/index can
+// be unit-tested in isolation; the bridge lives here.
+
+// Embedding is a single row of rag_embeddings as the application sees
+// it. Vector is the raw little-endian-packed BLOB; rag.UnpackVector
+// converts to []float32. Source/SourceID together uniquely identify
+// the originating object (e.g. source="message", source_id=msg_id).
+type Embedding struct {
+	ID          int64
+	Source      string
+	SourceID    string
+	SessionID   sql.NullString
+	ContentHash string
+	Text        string
+	Model       string
+	Dim         int
+	Vector      []byte
+	CreatedAt   int64 // unix seconds
+}
+
+// ErrEmbeddingNotFound is returned by GetEmbeddingByHash and
+// GetEmbedding when no row matches. Callers use errors.Is to detect
+// the absence so they can fall through to "embed and write".
+var ErrEmbeddingNotFound = errors.New("storage: embedding not found")
+
+// UpsertEmbedding writes (or updates) an embedding row. The UNIQUE
+// constraint on (source, source_id, model) lets the same content be
+// re-indexed under a different model without colliding; calling
+// UpsertEmbedding twice with the same (source, source_id, model)
+// updates the existing row.
+//
+// Vector dim is taken from len(vector)/4 — callers that have already
+// packed via rag.PackVector should pass the original dim explicitly.
+// We accept dim here so the row is self-describing without trusting
+// arithmetic on the BLOB length (extra defence against blob/dim drift).
+func (d *DB) UpsertEmbedding(e Embedding) error {
+	if e.Source == "" || e.SourceID == "" || e.Model == "" {
+		return fmt.Errorf("storage: UpsertEmbedding: source / source_id / model required")
+	}
+	if e.Dim <= 0 || len(e.Vector) != 4*e.Dim {
+		return fmt.Errorf("storage: UpsertEmbedding: dim=%d but len(vector)=%d (want %d)",
+			e.Dim, len(e.Vector), 4*e.Dim)
+	}
+	if e.ContentHash == "" {
+		return fmt.Errorf("storage: UpsertEmbedding: content_hash required")
+	}
+	if e.CreatedAt == 0 {
+		e.CreatedAt = time.Now().Unix()
+	}
+	const q = `
+INSERT INTO rag_embeddings
+  (source, source_id, session_id, content_hash, text, model, dim, vector, created_at)
+VALUES
+  (?,      ?,         ?,          ?,            ?,    ?,     ?,   ?,      ?)
+ON CONFLICT(source, source_id, model) DO UPDATE SET
+  session_id   = excluded.session_id,
+  content_hash = excluded.content_hash,
+  text         = excluded.text,
+  dim          = excluded.dim,
+  vector       = excluded.vector,
+  created_at   = excluded.created_at`
+	_, err := d.db.Exec(q,
+		e.Source, e.SourceID, e.SessionID,
+		e.ContentHash, e.Text, e.Model,
+		e.Dim, e.Vector, e.CreatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("storage: UpsertEmbedding: %w", err)
+	}
+	return nil
+}
+
+// GetEmbeddingByHash returns the most recent embedding row whose
+// (content_hash, model) pair matches. The dedup gate before re-
+// embedding: identical content under the same model is a cache hit.
+//
+// Returns ErrEmbeddingNotFound when no row matches. The model arg is
+// required because the same hash can have multiple rows under
+// different embedding models.
+func (d *DB) GetEmbeddingByHash(contentHash, model string) (*Embedding, error) {
+	if contentHash == "" || model == "" {
+		return nil, fmt.Errorf("storage: GetEmbeddingByHash: content_hash + model required")
+	}
+	const q = `
+SELECT id, source, source_id, session_id, content_hash, text, model, dim, vector, created_at
+FROM   rag_embeddings
+WHERE  content_hash = ? AND model = ?
+ORDER  BY created_at DESC
+LIMIT  1`
+	row := d.db.QueryRow(q, contentHash, model)
+	e := &Embedding{}
+	if err := row.Scan(
+		&e.ID, &e.Source, &e.SourceID, &e.SessionID,
+		&e.ContentHash, &e.Text, &e.Model,
+		&e.Dim, &e.Vector, &e.CreatedAt,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrEmbeddingNotFound
+		}
+		return nil, fmt.Errorf("storage: GetEmbeddingByHash: %w", err)
+	}
+	return e, nil
+}
+
+// ListEmbeddingsBySession returns every embedding row tied to a
+// session, ordered by id ASC (insertion order). Used by:
+//
+//   - The next-slice search path, which loads candidates for a
+//     cosine-similarity scan when sqlite-vec is not yet on top.
+//   - Per-session purges (delete-on-session-end) — callers list, then
+//     bulk-delete by id.
+func (d *DB) ListEmbeddingsBySession(sessionID string) ([]Embedding, error) {
+	if sessionID == "" {
+		return nil, fmt.Errorf("storage: ListEmbeddingsBySession: session_id required")
+	}
+	const q = `
+SELECT id, source, source_id, session_id, content_hash, text, model, dim, vector, created_at
+FROM   rag_embeddings
+WHERE  session_id = ?
+ORDER  BY id ASC`
+	rows, err := d.db.Query(q, sessionID)
+	if err != nil {
+		return nil, fmt.Errorf("storage: ListEmbeddingsBySession: %w", err)
+	}
+	defer rows.Close()
+	var out []Embedding
+	for rows.Next() {
+		var e Embedding
+		if err := rows.Scan(
+			&e.ID, &e.Source, &e.SourceID, &e.SessionID,
+			&e.ContentHash, &e.Text, &e.Model,
+			&e.Dim, &e.Vector, &e.CreatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("storage: ListEmbeddingsBySession scan: %w", err)
+		}
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}
+
+// DeleteEmbeddingsBySession removes every embedding tied to a
+// session. Returns the count of deleted rows. Used by session-end
+// hooks so a transient chat doesn't leave embeddings lingering.
+func (d *DB) DeleteEmbeddingsBySession(sessionID string) (int64, error) {
+	if sessionID == "" {
+		return 0, fmt.Errorf("storage: DeleteEmbeddingsBySession: session_id required")
+	}
+	res, err := d.db.Exec(
+		`DELETE FROM rag_embeddings WHERE session_id = ?`, sessionID)
+	if err != nil {
+		return 0, fmt.Errorf("storage: DeleteEmbeddingsBySession: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("storage: DeleteEmbeddingsBySession affected: %w", err)
+	}
+	return n, nil
+}
+
+// GetRAGState reads a value from the rag_state cursor table. Returns
+// ("", false, nil) when the key isn't set yet — callers treat that
+// as "start from the beginning".
+func (d *DB) GetRAGState(key string) (string, bool, error) {
+	if key == "" {
+		return "", false, fmt.Errorf("storage: GetRAGState: key required")
+	}
+	var v string
+	err := d.db.QueryRow(`SELECT value FROM rag_state WHERE key = ?`, key).Scan(&v)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("storage: GetRAGState: %w", err)
+	}
+	return v, true, nil
+}
+
+// SetRAGState upserts a single key/value into rag_state. Used by the
+// embedder watcher to record its progress (last_indexed_event_id,
+// last_indexed_message_id, etc.) so a crash-resume picks up cleanly.
+func (d *DB) SetRAGState(key, value string) error {
+	if key == "" {
+		return fmt.Errorf("storage: SetRAGState: key required")
+	}
+	_, err := d.db.Exec(
+		`INSERT INTO rag_state (key, value) VALUES (?, ?)
+		 ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+		key, value,
+	)
+	if err != nil {
+		return fmt.Errorf("storage: SetRAGState: %w", err)
+	}
+	return nil
+}

--- a/internal/storage/rag_test.go
+++ b/internal/storage/rag_test.go
@@ -1,0 +1,260 @@
+package storage
+
+import (
+	"database/sql"
+	"errors"
+	"testing"
+)
+
+// Phase 13 WS#13.B — typed-CRUD tests over the rag_embeddings +
+// rag_state schema. Tests own the contract the rag package will rely
+// on: Upsert obeys the UNIQUE constraint, GetByHash distinguishes
+// model variants, session list/delete are session-scoped, state
+// cursor round-trips.
+
+// makeVector returns a 4-byte-per-dim BLOB filled with zero bytes —
+// content is irrelevant to these tests, only length and dim matching.
+func makeVector(dim int) []byte { return make([]byte, 4*dim) }
+
+func seedEmbedding(t *testing.T, db *DB, source, sourceID, model string) Embedding {
+	t.Helper()
+	e := Embedding{
+		Source:      source,
+		SourceID:    sourceID,
+		SessionID:   sql.NullString{String: "sess-1", Valid: true},
+		ContentHash: "hash-" + sourceID,
+		Text:        "text-" + sourceID,
+		Model:       model,
+		Dim:         8,
+		Vector:      makeVector(8),
+		CreatedAt:   1700000000,
+	}
+	if err := db.UpsertEmbedding(e); err != nil {
+		t.Fatalf("seedEmbedding(%s/%s/%s): %v", source, sourceID, model, err)
+	}
+	return e
+}
+
+func TestUpsertEmbedding_Insert(t *testing.T) {
+	db := openTestDB(t)
+	e := seedEmbedding(t, db, "msg", "id-1", "model-A")
+
+	got, err := db.GetEmbeddingByHash(e.ContentHash, e.Model)
+	if err != nil {
+		t.Fatalf("GetEmbeddingByHash: %v", err)
+	}
+	if got.SourceID != "id-1" || got.Model != "model-A" {
+		t.Errorf("got %+v, mismatched on insert", got)
+	}
+}
+
+func TestUpsertEmbedding_UpdateOnConflict(t *testing.T) {
+	db := openTestDB(t)
+	first := seedEmbedding(t, db, "msg", "id-1", "model-A")
+
+	// Same (source, source_id, model) — must update, not insert.
+	updated := Embedding{
+		Source: "msg", SourceID: "id-1",
+		SessionID:   sql.NullString{String: "sess-2", Valid: true},
+		ContentHash: "hash-CHANGED",
+		Text:        "text-CHANGED", Model: "model-A",
+		Dim: 8, Vector: makeVector(8), CreatedAt: 1700000999,
+	}
+	if err := db.UpsertEmbedding(updated); err != nil {
+		t.Fatalf("upsert update: %v", err)
+	}
+
+	// Original hash should no longer find a row.
+	if _, err := db.GetEmbeddingByHash(first.ContentHash, "model-A"); !errors.Is(err, ErrEmbeddingNotFound) {
+		t.Errorf("expected ErrEmbeddingNotFound for old hash, got %v", err)
+	}
+	got, err := db.GetEmbeddingByHash("hash-CHANGED", "model-A")
+	if err != nil {
+		t.Fatalf("GetEmbeddingByHash new hash: %v", err)
+	}
+	if got.Text != "text-CHANGED" || got.SessionID.String != "sess-2" {
+		t.Errorf("update did not propagate: %+v", got)
+	}
+
+	// Sanity: only ONE row total under (msg, id-1).
+	var n int
+	if err := db.db.QueryRow(
+		`SELECT COUNT(*) FROM rag_embeddings WHERE source='msg' AND source_id='id-1'`,
+	).Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("UNIQUE constraint slipped — row count = %d, want 1", n)
+	}
+}
+
+func TestUpsertEmbedding_DistinctModelsCoexist(t *testing.T) {
+	db := openTestDB(t)
+	seedEmbedding(t, db, "msg", "id-1", "model-A")
+	seedEmbedding(t, db, "msg", "id-1", "model-B")
+
+	// Same content_hash + DIFFERENT models — both rows persist.
+	a, err := db.GetEmbeddingByHash("hash-id-1", "model-A")
+	if err != nil {
+		t.Fatalf("model-A lookup: %v", err)
+	}
+	b, err := db.GetEmbeddingByHash("hash-id-1", "model-B")
+	if err != nil {
+		t.Fatalf("model-B lookup: %v", err)
+	}
+	if a.ID == b.ID {
+		t.Errorf("expected distinct rows, got same id %d", a.ID)
+	}
+}
+
+func TestUpsertEmbedding_ValidationErrors(t *testing.T) {
+	db := openTestDB(t)
+	cases := []struct {
+		name string
+		e    Embedding
+	}{
+		{"empty_source", Embedding{SourceID: "x", Model: "m", Dim: 1, Vector: []byte{0, 0, 0, 0}, ContentHash: "h"}},
+		{"empty_source_id", Embedding{Source: "s", Model: "m", Dim: 1, Vector: []byte{0, 0, 0, 0}, ContentHash: "h"}},
+		{"empty_model", Embedding{Source: "s", SourceID: "x", Dim: 1, Vector: []byte{0, 0, 0, 0}, ContentHash: "h"}},
+		{"dim_zero", Embedding{Source: "s", SourceID: "x", Model: "m", Dim: 0, Vector: []byte{}, ContentHash: "h"}},
+		{"dim_blob_mismatch", Embedding{Source: "s", SourceID: "x", Model: "m", Dim: 4, Vector: []byte{0, 0, 0, 0}, ContentHash: "h"}},
+		{"empty_hash", Embedding{Source: "s", SourceID: "x", Model: "m", Dim: 1, Vector: []byte{0, 0, 0, 0}, ContentHash: ""}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := db.UpsertEmbedding(tc.e); err == nil {
+				t.Error("expected validation error")
+			}
+		})
+	}
+}
+
+func TestGetEmbeddingByHash_NotFound(t *testing.T) {
+	db := openTestDB(t)
+	_, err := db.GetEmbeddingByHash("nope", "model-A")
+	if !errors.Is(err, ErrEmbeddingNotFound) {
+		t.Errorf("err = %v, want ErrEmbeddingNotFound", err)
+	}
+}
+
+func TestListEmbeddingsBySession(t *testing.T) {
+	db := openTestDB(t)
+	// Seed three rows in two sessions.
+	for i, sid := range []string{"sess-A", "sess-A", "sess-B"} {
+		e := Embedding{
+			Source: "msg", SourceID: idForIndex(i),
+			SessionID:   sql.NullString{String: sid, Valid: true},
+			ContentHash: "h-" + idForIndex(i),
+			Text:        "t-" + idForIndex(i),
+			Model:       "m", Dim: 4, Vector: makeVector(4),
+			CreatedAt: int64(1700000000 + i),
+		}
+		if err := db.UpsertEmbedding(e); err != nil {
+			t.Fatalf("seed[%d]: %v", i, err)
+		}
+	}
+
+	a, err := db.ListEmbeddingsBySession("sess-A")
+	if err != nil {
+		t.Fatalf("List sess-A: %v", err)
+	}
+	if len(a) != 2 {
+		t.Errorf("sess-A count = %d, want 2", len(a))
+	}
+	b, err := db.ListEmbeddingsBySession("sess-B")
+	if err != nil {
+		t.Fatalf("List sess-B: %v", err)
+	}
+	if len(b) != 1 {
+		t.Errorf("sess-B count = %d, want 1", len(b))
+	}
+
+	// Insertion-order ordering.
+	if a[0].SourceID > a[1].SourceID {
+		t.Errorf("ListEmbeddingsBySession not ASC: %q,%q", a[0].SourceID, a[1].SourceID)
+	}
+}
+
+func TestDeleteEmbeddingsBySession(t *testing.T) {
+	db := openTestDB(t)
+	for i, sid := range []string{"sess-A", "sess-A", "sess-B"} {
+		e := Embedding{
+			Source: "msg", SourceID: idForIndex(i),
+			SessionID:   sql.NullString{String: sid, Valid: true},
+			ContentHash: "h-" + idForIndex(i),
+			Text:        "t-" + idForIndex(i),
+			Model:       "m", Dim: 4, Vector: makeVector(4),
+			CreatedAt: 1700000000,
+		}
+		if err := db.UpsertEmbedding(e); err != nil {
+			t.Fatalf("seed[%d]: %v", i, err)
+		}
+	}
+
+	n, err := db.DeleteEmbeddingsBySession("sess-A")
+	if err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("deleted = %d, want 2", n)
+	}
+
+	// sess-B intact.
+	rest, err := db.ListEmbeddingsBySession("sess-B")
+	if err != nil {
+		t.Fatalf("List sess-B post-delete: %v", err)
+	}
+	if len(rest) != 1 {
+		t.Errorf("sess-B affected by sess-A delete: count = %d", len(rest))
+	}
+}
+
+func TestRAGState_RoundTrip(t *testing.T) {
+	db := openTestDB(t)
+
+	// Unset key returns ok=false, no error.
+	v, ok, err := db.GetRAGState("missing")
+	if err != nil {
+		t.Fatalf("Get missing: %v", err)
+	}
+	if ok || v != "" {
+		t.Errorf("missing key returned ok=%v v=%q, want false/empty", ok, v)
+	}
+
+	// Set + Get.
+	if err := db.SetRAGState("cursor", "42"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	v, ok, err = db.GetRAGState("cursor")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !ok || v != "42" {
+		t.Errorf("got ok=%v v=%q, want true/42", ok, v)
+	}
+
+	// Update overwrites.
+	if err := db.SetRAGState("cursor", "100"); err != nil {
+		t.Fatalf("Set update: %v", err)
+	}
+	v, _, _ = db.GetRAGState("cursor")
+	if v != "100" {
+		t.Errorf("after update, v = %q, want 100", v)
+	}
+}
+
+func TestRAGState_EmptyKeyError(t *testing.T) {
+	db := openTestDB(t)
+	if _, _, err := db.GetRAGState(""); err == nil {
+		t.Error("Get empty key: expected error")
+	}
+	if err := db.SetRAGState("", "v"); err == nil {
+		t.Error("Set empty key: expected error")
+	}
+}
+
+// idForIndex returns a stable string id for the seed loop. Defined
+// here (not as a const) because Go doesn't allow const slices.
+func idForIndex(i int) string {
+	return [...]string{"a", "b", "c", "d", "e", "f"}[i%6]
+}


### PR DESCRIPTION
## Summary

Builds on the WS#13.B schema substrate (#40) with two small sealed primitives. No embedder, no watcher, no search HTTP endpoint yet — those land in follow-up slices on top of these.

## `internal/rag/codec.go` — vector codec + content hash + similarity

- \`PackVector\` / \`UnpackVector\` — float32 ↔ little-endian BLOB, bit-exact round-trip including NaN, ±Inf, signed zero. \`ErrDimMismatch\` surfaces corruption at the decode boundary instead of at the SQLite write site.
- \`ContentHash\` — sha256 hex of raw bytes; drives the \`idx_rag_hash\` cache-hit path. Documented as a dedup key, **not** a security primitive.
- \`CosineSimilarity\` — pairwise score, returns 0 for either-zero vectors so ranking code never sees NaN. Lands alongside the codec because the search slice consumes the same primitives.

## `internal/storage/rag.go` — typed CRUD over `rag_embeddings` + `rag_state`

- \`UpsertEmbedding\` — \`INSERT ... ON CONFLICT(source, source_id, model) DO UPDATE\`, leveraging the UNIQUE constraint so one (source,source_id) can coexist under multiple embedding models without colliding. Validates Source/SourceID/Model/Dim/Vector/ContentHash before touching SQLite.
- \`GetEmbeddingByHash(hash, model)\` — returns \`ErrEmbeddingNotFound\` (cache-miss → embed → write pattern); requires the (hash, model) pair because the same hash under different models is two distinct rows.
- \`ListEmbeddingsBySession\` / \`DeleteEmbeddingsBySession\` — session-scoped so transient chats can purge embeddings on session-end.
- \`GetRAGState\` / \`SetRAGState\` — key/value cursor for the future embedder watcher; \`Get\` returns \`(val, ok, err)\` so the empty cursor isn't an error.

## Test plan

- [x] \`go test ./internal/rag/\` — 11 tests: pack/unpack round-trip across ordinary floats + NaN/Inf/-0; LE byte ordering pinned to \`0x3F800000\` for 1.0; \`ErrDimMismatch\` cases; \`ContentHash\` determinism + known sha256 for \`"hello world"\`; \`CosineSimilarity\` cases (identical/orthogonal/opposite/scaled/45deg) + zero-vector → 0 invariant.
- [x] \`go test ./internal/storage/ -run TestUpsertEmbedding\` etc. — 9 tests covering Upsert insert/update/distinct-models, \`GetEmbeddingByHash\` not-found, List/Delete by session, \`rag_state\` round-trip, validation errors.
- [x] \`go test ./...\` — full suite 457/457 pass.
- [x] \`go build ./...\` — green.
- [x] \`golangci-lint run ./internal/storage/ ./internal/rag/\` — 0 issues.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)