### PR TITLE
feat(rag): WS#13.B embedder client — OpenAI-compatible /v1/embeddings

### DIFF
--- a/internal/rag/embedder.go
+++ b/internal/rag/embedder.go
@@ -1,0 +1,249 @@
+package rag
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Embedder turns text into a fixed-dimensionality float32 vector. The
+// next-slice index wrapper consumes Embedder; tests inject a fake so
+// no HTTP server is required for unit-level coverage.
+//
+// Embed returns the vector + the dimensionality + the model id the
+// provider actually used (for the rare case where a request for
+// model "X" gets back model "X-v2"; we record what was actually
+// computed so re-index detection is accurate).
+//
+// EmbedBatch is the bulk variant — providers commonly accept an
+// array `input` for a single round-trip; the order of vectors in
+// the returned slice matches the input order. Implementations MUST
+// either return all vectors or an error; partial results are
+// rejected at the boundary so callers don't have to track which
+// inputs succeeded.
+type Embedder interface {
+	Embed(ctx context.Context, text string) ([]float32, error)
+	EmbedBatch(ctx context.Context, texts []string) ([][]float32, error)
+	Model() string
+	Dim() int
+}
+
+// ErrEmbedFailed wraps non-network failures from the embedder
+// (provider returned a structured error, decoded an empty data
+// array, dim disagreed with a previous call). errors.Is supports
+// matching either the wrapper or the underlying cause.
+var ErrEmbedFailed = errors.New("rag: embed failed")
+
+// HTTPEmbedderConfig is the constructor input for an OpenAI-shaped
+// embeddings client. Most providers (OpenAI, Regolo, Ollama,
+// LM Studio, vLLM, llama.cpp) implement the same /embeddings shape.
+type HTTPEmbedderConfig struct {
+	// BaseURL is the provider root, e.g. "https://api.regolo.ai/v1".
+	// Trailing slashes are trimmed. Required.
+	BaseURL string
+	// APIKey is the bearer token. Empty is OK for local providers
+	// (Ollama, LM Studio, vLLM, llama.cpp).
+	APIKey string
+	// Model is the embedding model id, e.g.
+	// "regolo:bge-small-en-v1.5". Required — the rag_embeddings.model
+	// column is keyed off this string, so changing it triggers a
+	// re-embed pass for affected rows.
+	Model string
+	// Dim is the expected output dimensionality. Required for
+	// pre-flight validation: providers that silently return a
+	// different dim from a model upgrade would otherwise corrupt
+	// the rag_embeddings.dim column. Set to 0 to skip validation
+	// (only useful for tests that don't care).
+	Dim int
+	// Timeout caps a single HTTP round-trip. 0 = no timeout
+	// (honour the caller-supplied context only). Defaults to 30s
+	// when constructed via NewHTTPEmbedder.
+	Timeout time.Duration
+	// HTTPClient lets tests inject a custom client (e.g. an
+	// httptest server's RoundTripper). nil = a fresh net/http
+	// Client with Timeout.
+	HTTPClient *http.Client
+}
+
+// HTTPEmbedder implements Embedder against an OpenAI-compatible
+// /v1/embeddings endpoint.
+type HTTPEmbedder struct {
+	baseURL string
+	apiKey  string
+	model   string
+	dim     int
+	client  *http.Client
+}
+
+// NewHTTPEmbedder validates cfg and returns an Embedder. Returns an
+// error when the configuration is unusable so callers don't carry a
+// half-broken client around.
+func NewHTTPEmbedder(cfg HTTPEmbedderConfig) (*HTTPEmbedder, error) {
+	if cfg.BaseURL == "" {
+		return nil, fmt.Errorf("rag: HTTPEmbedder: BaseURL required")
+	}
+	if cfg.Model == "" {
+		return nil, fmt.Errorf("rag: HTTPEmbedder: Model required")
+	}
+	if cfg.Dim < 0 {
+		return nil, fmt.Errorf("rag: HTTPEmbedder: Dim must be >= 0, got %d", cfg.Dim)
+	}
+	hc := cfg.HTTPClient
+	if hc == nil {
+		t := cfg.Timeout
+		if t == 0 {
+			t = 30 * time.Second
+		}
+		hc = &http.Client{Timeout: t}
+	}
+	return &HTTPEmbedder{
+		baseURL: strings.TrimRight(cfg.BaseURL, "/"),
+		apiKey:  cfg.APIKey,
+		model:   cfg.Model,
+		dim:     cfg.Dim,
+		client:  hc,
+	}, nil
+}
+
+// Model returns the configured embedding model id.
+func (e *HTTPEmbedder) Model() string { return e.model }
+
+// Dim returns the configured output dimensionality. Zero means
+// "validation skipped" — the index writer should fall back to the
+// length of the first returned vector in that case.
+func (e *HTTPEmbedder) Dim() int { return e.dim }
+
+// Embed sends a single-input embedding request. Returns
+// ErrEmbedFailed-wrapped errors for provider-side problems; the
+// raw context-cancellation / network errors pass through unwrapped
+// so callers can distinguish "retry later" from "fix your config".
+func (e *HTTPEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+	out, err := e.EmbedBatch(ctx, []string{text})
+	if err != nil {
+		return nil, err
+	}
+	if len(out) != 1 {
+		return nil, fmt.Errorf("%w: expected 1 vector, got %d", ErrEmbedFailed, len(out))
+	}
+	return out[0], nil
+}
+
+// embedRequest mirrors the OpenAI /embeddings request shape.
+type embedRequest struct {
+	Model string   `json:"model"`
+	Input []string `json:"input"`
+}
+
+// embedResponse mirrors the OpenAI /embeddings response shape.
+type embedResponse struct {
+	Data []struct {
+		Embedding []float32 `json:"embedding"`
+		Index     int       `json:"index"`
+	} `json:"data"`
+	Model string `json:"model"`
+	Error *struct {
+		Message string `json:"message"`
+		Type    string `json:"type"`
+	} `json:"error,omitempty"`
+}
+
+// EmbedBatch sends multi-input embedding request. Re-orders the
+// returned vectors by data[i].index so callers see input-aligned
+// output regardless of provider re-ordering.
+func (e *HTTPEmbedder) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
+	if len(texts) == 0 {
+		return nil, fmt.Errorf("%w: empty input batch", ErrEmbedFailed)
+	}
+
+	body, err := json.Marshal(embedRequest{Model: e.model, Input: texts})
+	if err != nil {
+		return nil, fmt.Errorf("rag: marshal embed request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		e.baseURL+"/embeddings", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("rag: build embed request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	if e.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+e.apiKey)
+	}
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("rag: embed http: %w", err)
+	}
+	defer resp.Body.Close()
+
+	rawBody, err := io.ReadAll(io.LimitReader(resp.Body, 16*1024*1024))
+	if err != nil {
+		return nil, fmt.Errorf("rag: read embed body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%w: status %d: %s",
+			ErrEmbedFailed, resp.StatusCode, truncateForLog(string(rawBody)))
+	}
+
+	var out embedResponse
+	if err := json.Unmarshal(rawBody, &out); err != nil {
+		return nil, fmt.Errorf("%w: decode body: %v", ErrEmbedFailed, err)
+	}
+	if out.Error != nil {
+		return nil, fmt.Errorf("%w: provider error: %s",
+			ErrEmbedFailed, out.Error.Message)
+	}
+	if len(out.Data) != len(texts) {
+		return nil, fmt.Errorf("%w: returned %d vectors for %d inputs",
+			ErrEmbedFailed, len(out.Data), len(texts))
+	}
+
+	// Order by index — provider may return them in arrival order.
+	vectors := make([][]float32, len(texts))
+	for _, d := range out.Data {
+		if d.Index < 0 || d.Index >= len(texts) {
+			return nil, fmt.Errorf("%w: out-of-range index %d (batch size %d)",
+				ErrEmbedFailed, d.Index, len(texts))
+		}
+		if vectors[d.Index] != nil {
+			return nil, fmt.Errorf("%w: duplicate index %d in response",
+				ErrEmbedFailed, d.Index)
+		}
+		if e.dim > 0 && len(d.Embedding) != e.dim {
+			return nil, fmt.Errorf("%w: embedding[%d] dim = %d, configured Dim = %d",
+				ErrEmbedFailed, d.Index, len(d.Embedding), e.dim)
+		}
+		if len(d.Embedding) == 0 {
+			return nil, fmt.Errorf("%w: embedding[%d] is empty",
+				ErrEmbedFailed, d.Index)
+		}
+		vectors[d.Index] = d.Embedding
+	}
+	for i, v := range vectors {
+		if v == nil {
+			return nil, fmt.Errorf("%w: response missing index %d",
+				ErrEmbedFailed, i)
+		}
+	}
+	return vectors, nil
+}
+
+// truncateForLog caps an error body so a malformed-JSON page from a
+// proxy doesn't dump a megabyte into the user's log. The full body
+// is already capped at 16MB by the LimitReader; this is a second
+// layer for error formatting only.
+func truncateForLog(s string) string {
+	const max = 512
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "...(truncated)"
+}

--- a/internal/rag/embedder_test.go
+++ b/internal/rag/embedder_test.go
@@ -1,0 +1,364 @@
+package rag
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Phase 13 WS#13.B — embedder client tests. Uses httptest fakes so
+// the suite stays hermetic; no real provider call ever fires.
+
+// fakeEmbedServer returns an httptest.Server that responds to
+// /embeddings with the supplied vectors (one per input text).
+// The handler closure can be replaced via the returned hook to
+// inject error cases.
+type fakeEmbedServer struct {
+	*httptest.Server
+	handler func(w http.ResponseWriter, r *http.Request)
+}
+
+func newFakeEmbedServer(t *testing.T) *fakeEmbedServer {
+	t.Helper()
+	s := &fakeEmbedServer{}
+	s.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if s.handler != nil {
+			s.handler(w, r)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(s.Close)
+	return s
+}
+
+// happyHandler echoes back len(input) vectors of dim D, each filled
+// with the input's index as a float32 (so callers can verify ordering).
+func happyHandler(dim int) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req embedRequest
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &req)
+		var out embedResponse
+		out.Model = req.Model
+		for i := range req.Input {
+			vec := make([]float32, dim)
+			for j := range vec {
+				vec[j] = float32(i)
+			}
+			out.Data = append(out.Data, struct {
+				Embedding []float32 `json:"embedding"`
+				Index     int       `json:"index"`
+			}{Embedding: vec, Index: i})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(out)
+	}
+}
+
+func TestNewHTTPEmbedder_Validation(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		cfg  HTTPEmbedderConfig
+	}{
+		{"no_baseurl", HTTPEmbedderConfig{Model: "m"}},
+		{"no_model", HTTPEmbedderConfig{BaseURL: "http://x"}},
+		{"negative_dim", HTTPEmbedderConfig{BaseURL: "http://x", Model: "m", Dim: -1}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := NewHTTPEmbedder(tc.cfg); err == nil {
+				t.Error("expected validation error")
+			}
+		})
+	}
+}
+
+func TestHTTPEmbedder_Embed_HappyPath(t *testing.T) {
+	t.Parallel()
+	srv := newFakeEmbedServer(t)
+	srv.handler = happyHandler(8)
+	em, err := NewHTTPEmbedder(HTTPEmbedderConfig{
+		BaseURL: srv.URL, Model: "m-1", Dim: 8, APIKey: "tok",
+	})
+	if err != nil {
+		t.Fatalf("NewHTTPEmbedder: %v", err)
+	}
+
+	v, err := em.Embed(context.Background(), "hello")
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if len(v) != 8 {
+		t.Errorf("len = %d, want 8", len(v))
+	}
+	if v[0] != 0 {
+		t.Errorf("v[0] = %v, want 0 (input index)", v[0])
+	}
+	if em.Model() != "m-1" || em.Dim() != 8 {
+		t.Errorf("Model/Dim getters wrong: %q/%d", em.Model(), em.Dim())
+	}
+}
+
+func TestHTTPEmbedder_EmbedBatch_OrderingAndAuth(t *testing.T) {
+	t.Parallel()
+	srv := newFakeEmbedServer(t)
+	gotAuth := ""
+	srv.handler = func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		// Reply with vectors in REVERSE order (provider misbehaving)
+		// so the test pins our re-ordering by Index.
+		var req embedRequest
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &req)
+		var out embedResponse
+		for i := len(req.Input) - 1; i >= 0; i-- {
+			vec := make([]float32, 4)
+			vec[0] = float32(i)
+			out.Data = append(out.Data, struct {
+				Embedding []float32 `json:"embedding"`
+				Index     int       `json:"index"`
+			}{Embedding: vec, Index: i})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(out)
+	}
+
+	em, _ := NewHTTPEmbedder(HTTPEmbedderConfig{
+		BaseURL: srv.URL, Model: "m", Dim: 4, APIKey: "secret-key",
+	})
+	vs, err := em.EmbedBatch(context.Background(), []string{"a", "b", "c"})
+	if err != nil {
+		t.Fatalf("EmbedBatch: %v", err)
+	}
+	if len(vs) != 3 {
+		t.Fatalf("len = %d, want 3", len(vs))
+	}
+	for i, v := range vs {
+		if v[0] != float32(i) {
+			t.Errorf("vs[%d][0] = %v, want %v — re-ordering broken",
+				i, v[0], float32(i))
+		}
+	}
+	if gotAuth != "Bearer secret-key" {
+		t.Errorf("Authorization = %q, want Bearer secret-key", gotAuth)
+	}
+}
+
+func TestHTTPEmbedder_NoAPIKey_OmitsAuth(t *testing.T) {
+	t.Parallel()
+	srv := newFakeEmbedServer(t)
+	gotAuth := "<unset>"
+	srv.handler = func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		happyHandler(2)(w, r)
+	}
+
+	em, _ := NewHTTPEmbedder(HTTPEmbedderConfig{
+		BaseURL: srv.URL, Model: "m", Dim: 2,
+	})
+	if _, err := em.Embed(context.Background(), "x"); err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if gotAuth != "" {
+		t.Errorf("expected empty Authorization for local provider, got %q", gotAuth)
+	}
+}
+
+func TestHTTPEmbedder_DimMismatch(t *testing.T) {
+	t.Parallel()
+	srv := newFakeEmbedServer(t)
+	// Server returns 8-dim, embedder configured for 4-dim.
+	srv.handler = happyHandler(8)
+
+	em, _ := NewHTTPEmbedder(HTTPEmbedderConfig{
+		BaseURL: srv.URL, Model: "m", Dim: 4,
+	})
+	_, err := em.Embed(context.Background(), "x")
+	if !errors.Is(err, ErrEmbedFailed) {
+		t.Errorf("err = %v, want ErrEmbedFailed", err)
+	}
+	if !strings.Contains(err.Error(), "dim") {
+		t.Errorf("err message should mention dim, got %v", err)
+	}
+}
+
+func TestHTTPEmbedder_DimZero_AcceptsAny(t *testing.T) {
+	t.Parallel()
+	// Dim=0 means skip validation — useful for tests + first-time
+	// provisioning where the caller doesn't know the model dim yet.
+	srv := newFakeEmbedServer(t)
+	srv.handler = happyHandler(384)
+
+	em, _ := NewHTTPEmbedder(HTTPEmbedderConfig{
+		BaseURL: srv.URL, Model: "m", Dim: 0,
+	})
+	v, err := em.Embed(context.Background(), "x")
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if len(v) != 384 {
+		t.Errorf("len = %d, want 384 (server's dim)", len(v))
+	}
+}
+
+func TestHTTPEmbedder_HTTPError(t *testing.T) {
+	t.Parallel()
+	srv := newFakeEmbedServer(t)
+	srv.handler = func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":{"message":"out of credits"}}`, http.StatusPaymentRequired)
+	}
+	em, _ := NewHTTPEmbedder(HTTPEmbedderConfig{
+		BaseURL: srv.URL, Model: "m", Dim: 0,
+	})
+	_, err := em.Embed(context.Background(), "x")
+	if !errors.Is(err, ErrEmbedFailed) {
+		t.Errorf("err = %v, want wrapped ErrEmbedFailed", err)
+	}
+	if !strings.Contains(err.Error(), "402") {
+		t.Errorf("err should include status 402, got %v", err)
+	}
+}
+
+func TestHTTPEmbedder_StructuredError(t *testing.T) {
+	t.Parallel()
+	srv := newFakeEmbedServer(t)
+	srv.handler = func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"error":{"message":"model not found","type":"invalid_request_error"}}`))
+	}
+	em, _ := NewHTTPEmbedder(HTTPEmbedderConfig{
+		BaseURL: srv.URL, Model: "m", Dim: 0,
+	})
+	_, err := em.Embed(context.Background(), "x")
+	if !errors.Is(err, ErrEmbedFailed) {
+		t.Errorf("err = %v, want ErrEmbedFailed", err)
+	}
+	if !strings.Contains(err.Error(), "model not found") {
+		t.Errorf("err should include provider message, got %v", err)
+	}
+}
+
+func TestHTTPEmbedder_BatchSizeMismatch(t *testing.T) {
+	t.Parallel()
+	srv := newFakeEmbedServer(t)
+	// Server returns FEWER vectors than requested.
+	srv.handler = func(w http.ResponseWriter, r *http.Request) {
+		var out embedResponse
+		out.Data = append(out.Data, struct {
+			Embedding []float32 `json:"embedding"`
+			Index     int       `json:"index"`
+		}{Embedding: []float32{1, 2, 3}, Index: 0})
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(out)
+	}
+	em, _ := NewHTTPEmbedder(HTTPEmbedderConfig{
+		BaseURL: srv.URL, Model: "m", Dim: 0,
+	})
+	_, err := em.EmbedBatch(context.Background(), []string{"a", "b"})
+	if !errors.Is(err, ErrEmbedFailed) {
+		t.Errorf("err = %v, want ErrEmbedFailed", err)
+	}
+}
+
+func TestHTTPEmbedder_DuplicateIndex(t *testing.T) {
+	t.Parallel()
+	srv := newFakeEmbedServer(t)
+	srv.handler = func(w http.ResponseWriter, r *http.Request) {
+		var out embedResponse
+		// Two replies both at index 0 — provider bug we must reject.
+		for i := 0; i < 2; i++ {
+			out.Data = append(out.Data, struct {
+				Embedding []float32 `json:"embedding"`
+				Index     int       `json:"index"`
+			}{Embedding: []float32{0, 0}, Index: 0})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(out)
+	}
+	em, _ := NewHTTPEmbedder(HTTPEmbedderConfig{
+		BaseURL: srv.URL, Model: "m", Dim: 0,
+	})
+	_, err := em.EmbedBatch(context.Background(), []string{"a", "b"})
+	if !errors.Is(err, ErrEmbedFailed) {
+		t.Errorf("err = %v, want ErrEmbedFailed (dup index)", err)
+	}
+}
+
+func TestHTTPEmbedder_OutOfRangeIndex(t *testing.T) {
+	t.Parallel()
+	srv := newFakeEmbedServer(t)
+	srv.handler = func(w http.ResponseWriter, r *http.Request) {
+		out := embedResponse{Data: []struct {
+			Embedding []float32 `json:"embedding"`
+			Index     int       `json:"index"`
+		}{{Embedding: []float32{0}, Index: 99}}}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(out)
+	}
+	em, _ := NewHTTPEmbedder(HTTPEmbedderConfig{
+		BaseURL: srv.URL, Model: "m", Dim: 0,
+	})
+	_, err := em.EmbedBatch(context.Background(), []string{"a"})
+	if !errors.Is(err, ErrEmbedFailed) {
+		t.Errorf("err = %v, want ErrEmbedFailed", err)
+	}
+}
+
+func TestHTTPEmbedder_EmptyBatch(t *testing.T) {
+	t.Parallel()
+	em, _ := NewHTTPEmbedder(HTTPEmbedderConfig{
+		BaseURL: "http://x", Model: "m", Dim: 0,
+	})
+	_, err := em.EmbedBatch(context.Background(), nil)
+	if !errors.Is(err, ErrEmbedFailed) {
+		t.Errorf("err = %v, want ErrEmbedFailed (empty batch)", err)
+	}
+}
+
+func TestHTTPEmbedder_ContextCancel(t *testing.T) {
+	t.Parallel()
+	srv := newFakeEmbedServer(t)
+	// Slow handler that respects context cancellation.
+	srv.handler = func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-time.After(2 * time.Second):
+			happyHandler(2)(w, r)
+		}
+	}
+
+	em, _ := NewHTTPEmbedder(HTTPEmbedderConfig{
+		BaseURL: srv.URL, Model: "m", Dim: 2,
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	_, err := em.Embed(ctx, "x")
+	if err == nil {
+		t.Error("expected context-cancellation error")
+	}
+}
+
+func TestHTTPEmbedder_TrailingSlashInBaseURL(t *testing.T) {
+	t.Parallel()
+	srv := newFakeEmbedServer(t)
+	srv.handler = happyHandler(2)
+	em, err := NewHTTPEmbedder(HTTPEmbedderConfig{
+		BaseURL: srv.URL + "/", // trailing slash
+		Model:   "m", Dim: 2,
+	})
+	if err != nil {
+		t.Fatalf("NewHTTPEmbedder: %v", err)
+	}
+	if _, err := em.Embed(context.Background(), "x"); err != nil {
+		t.Errorf("trailing slash should be stripped, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Adds the \`Embedder\` interface + an HTTP implementation against the OpenAI-shaped \`/v1/embeddings\` endpoint that nine providers in our provider table already speak (OpenAI, Regolo, Ollama, LM Studio, vLLM, llama.cpp, OpenRouter, Groq, Anthropic).

Builds on the codec + storage helpers from #42; the next slice (\`rag.Index\`) will combine content-hash gating + Embedder + \`storage.UpsertEmbedding\` into one cache-then-fetch surface.

## Embedder interface

Small enough that future implementations (local sentence-transformers, ONNX runtime) can stand it up without the HTTP shape:

\`\`\`go
type Embedder interface {
    Embed(ctx, text) ([]float32, error)
    EmbedBatch(ctx, texts) ([][]float32, error)  // input-aligned
    Model() string
    Dim() int
}
\`\`\`

## HTTPEmbedder

- Config validates \`BaseURL\` + \`Model\` up front; misuse fails at construction, not first request.
- \`Dim\` validates response dimensionality before a row would be written. Set \`Dim=0\` to skip (provisioning).
- Returned vectors **reordered by \`data[i].index\`** so callers see input-aligned output regardless of provider reordering — pinned by an explicit reverse-order test.
- Auth header omitted when \`APIKey\` is empty (Ollama / LM Studio / vLLM / llama.cpp).
- 16MB body limit; structured provider errors and HTTP non-200s both wrap \`ErrEmbedFailed\` so callers use \`errors.Is\` for retry policy.
- Context cancellation passes through unwrapped so the chat loop can distinguish \"user aborted\" from \"fix your config.\"

## Test plan

Hermetic tests via \`httptest.NewServer\` — no real provider call ever fires.

- [x] Happy path: \`Embed\` returns one vector of the configured dim
- [x] \`EmbedBatch\` ordering: handler returns vectors in reverse, client must reorder by \`Index\`
- [x] Auth header on/off (\`Bearer secret-key\` vs absent)
- [x] Dim mismatch (server returns 8-dim, client configured 4-dim → \`ErrEmbedFailed\`)
- [x] \`Dim=0\` skips validation (provisioning)
- [x] HTTP error (402 body wrapped with status)
- [x] Structured provider error (200 body with \`error.message\`)
- [x] Batch size mismatch (fewer vectors than inputs)
- [x] Duplicate response index (provider bug → reject)
- [x] Out-of-range response index
- [x] Empty input batch
- [x] Context cancellation
- [x] Trailing slash on \`BaseURL\` normalisation
- [x] Construction validation (empty BaseURL / empty Model / negative Dim)
- [x] \`go test ./...\` — 474/474 pass
- [x] \`golangci-lint run ./internal/rag/\` — 0 issues

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)