### PR TITLE
feat(gateway): WS#13.B HTTP endpoints for the rag.Index

### DIFF
--- a/internal/gateway/rag.go
+++ b/internal/gateway/rag.go
@@ -1,0 +1,239 @@
+package gateway
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/euraika-labs/pan-agent/internal/rag"
+	"github.com/euraika-labs/pan-agent/internal/storage"
+)
+
+// Phase 13 WS#13.B — HTTP endpoints over the rag.Index.
+//
+// The slice is intentionally narrow:
+//
+//   POST   /v1/rag/index                              — Upsert one entry
+//   POST   /v1/rag/search                             — top-K cosine search
+//   DELETE /v1/rag/sessions/{id}/embeddings           — purge a session
+//   GET    /v1/rag/health                             — ready / not configured
+//
+// The Index instance is attached to the Server lazily (see
+// Server.AttachRAGIndex). When unattached, write/search endpoints
+// return 503 with a clear message; the health endpoint reports
+// "configured": false so the desktop UI can surface a setup hint.
+//
+// No Embedder configuration code is wired in this slice — that lands
+// alongside the desktop's RAG settings panel. Existing deployments
+// stay unaffected because the routes 503 until something calls
+// AttachRAGIndex.
+
+// AttachRAGIndex wires a configured rag.Index into the server. Safe to
+// call from main.go after Embedder construction; the handlers re-read
+// the pointer on every request through getRAGIndex so callers can
+// hot-swap the index without restarting the server.
+func (s *Server) AttachRAGIndex(idx *rag.Index) {
+	s.ragMu.Lock()
+	defer s.ragMu.Unlock()
+	s.ragIndex = idx
+}
+
+// getRAGIndex returns the current attached index under a read lock.
+// Returns nil when no index has been attached — handlers must check.
+func (s *Server) getRAGIndex() *rag.Index {
+	s.ragMu.RLock()
+	defer s.ragMu.RUnlock()
+	return s.ragIndex
+}
+
+// ---------------------------------------------------------------------------
+// Request / response shapes
+// ---------------------------------------------------------------------------
+
+type ragIndexRequest struct {
+	Source    string `json:"source"`
+	SourceID  string `json:"source_id"`
+	SessionID string `json:"session_id,omitempty"`
+	Text      string `json:"text"`
+}
+
+type ragIndexResponse struct {
+	Cached    bool             `json:"cached"`
+	Embedding *ragEmbeddingDTO `json:"embedding,omitempty"`
+}
+
+type ragEmbeddingDTO struct {
+	ID          int64  `json:"id"`
+	Source      string `json:"source"`
+	SourceID    string `json:"source_id"`
+	SessionID   string `json:"session_id,omitempty"`
+	ContentHash string `json:"content_hash"`
+	Text        string `json:"text"`
+	Model       string `json:"model"`
+	Dim         int    `json:"dim"`
+	CreatedAt   int64  `json:"created_at"`
+	// Vector is intentionally omitted: a 384-dim vector at 4 bytes/dim
+	// is 1.5KB per row; clients that need the raw vector should add a
+	// dedicated endpoint. The HTTP surface stays metadata-only.
+}
+
+func toEmbeddingDTO(e *storage.Embedding) *ragEmbeddingDTO {
+	if e == nil {
+		return nil
+	}
+	dto := &ragEmbeddingDTO{
+		ID: e.ID, Source: e.Source, SourceID: e.SourceID,
+		ContentHash: e.ContentHash, Text: e.Text, Model: e.Model,
+		Dim: e.Dim, CreatedAt: e.CreatedAt,
+	}
+	if e.SessionID.Valid {
+		dto.SessionID = e.SessionID.String
+	}
+	return dto
+}
+
+type ragSearchRequest struct {
+	Query     string  `json:"query"`
+	SessionID string  `json:"session_id"`
+	K         int     `json:"k,omitempty"`
+	MinScore  float32 `json:"min_score,omitempty"`
+}
+
+type ragSearchResponse struct {
+	Hits []ragSearchHit `json:"hits"`
+}
+
+type ragSearchHit struct {
+	Embedding *ragEmbeddingDTO `json:"embedding"`
+	Score     float32          `json:"score"`
+}
+
+type ragHealthResponse struct {
+	Configured bool   `json:"configured"`
+	Model      string `json:"model,omitempty"`
+	Dim        int    `json:"dim,omitempty"`
+}
+
+type ragDeleteResponse struct {
+	Deleted int64 `json:"deleted"`
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+// handleRAGIndex POSTs a single text into the index. Returns
+// {"cached": bool, "embedding": {...}} so the caller can tell whether
+// the embedder ran or the content-hash gate served a cache hit.
+func (s *Server) handleRAGIndex(w http.ResponseWriter, r *http.Request) {
+	idx := s.getRAGIndex()
+	if idx == nil {
+		writeAPIError(w, http.StatusServiceUnavailable,
+			"rag_unavailable", "RAG index not configured", nil)
+		return
+	}
+
+	var req ragIndexRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeAPIError(w, http.StatusBadRequest,
+			"invalid_request", "invalid JSON body", nil)
+		return
+	}
+
+	res, err := idx.Upsert(r.Context(), rag.IngestRequest{
+		Source: req.Source, SourceID: req.SourceID,
+		SessionID: req.SessionID, Text: req.Text,
+	})
+	if err != nil {
+		writeAPIError(w, http.StatusBadRequest,
+			"index_failed", err.Error(), nil)
+		return
+	}
+	writeJSON(w, http.StatusOK, ragIndexResponse{
+		Cached:    res.Cached,
+		Embedding: toEmbeddingDTO(res.Embedding),
+	})
+}
+
+// handleRAGSearch POSTs a query and returns the top-K hits as
+// metadata-only DTOs (vector bytes excluded — see ragEmbeddingDTO).
+func (s *Server) handleRAGSearch(w http.ResponseWriter, r *http.Request) {
+	idx := s.getRAGIndex()
+	if idx == nil {
+		writeAPIError(w, http.StatusServiceUnavailable,
+			"rag_unavailable", "RAG index not configured", nil)
+		return
+	}
+
+	var req ragSearchRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeAPIError(w, http.StatusBadRequest,
+			"invalid_request", "invalid JSON body", nil)
+		return
+	}
+
+	hits, err := idx.Search(r.Context(), rag.SearchRequest{
+		Query: req.Query, SessionID: req.SessionID,
+		K: req.K, MinScore: req.MinScore,
+	})
+	if err != nil {
+		writeAPIError(w, http.StatusBadRequest,
+			"search_failed", err.Error(), nil)
+		return
+	}
+
+	out := ragSearchResponse{Hits: make([]ragSearchHit, 0, len(hits))}
+	for _, h := range hits {
+		// Take a stable address of the loop variable so toEmbeddingDTO
+		// doesn't capture an aliased pointer (Go ≥1.22 makes this safe
+		// per-iteration but the explicit copy reads more clearly).
+		emb := h.Embedding
+		out.Hits = append(out.Hits, ragSearchHit{
+			Embedding: toEmbeddingDTO(&emb),
+			Score:     h.Score,
+		})
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// handleRAGSessionEmbeddingsDelete purges every embedding tied to
+// the session id from the URL. Doesn't require an attached Index —
+// the storage call works against whatever rows exist.
+func (s *Server) handleRAGSessionEmbeddingsDelete(w http.ResponseWriter, r *http.Request) {
+	sid := r.PathValue("id")
+	if sid == "" {
+		writeAPIError(w, http.StatusBadRequest,
+			"invalid_request", "session id required", nil)
+		return
+	}
+	n, err := s.db.DeleteEmbeddingsBySession(sid)
+	if err != nil {
+		writeAPIError(w, http.StatusInternalServerError,
+			"internal_error", err.Error(), nil)
+		return
+	}
+	writeJSON(w, http.StatusOK, ragDeleteResponse{Deleted: n})
+}
+
+// handleRAGHealth reports whether the index is configured. Returns
+// 200 in either case so the desktop UI can render a setup banner
+// without needing to distinguish "not yet wired" from a real error.
+func (s *Server) handleRAGHealth(w http.ResponseWriter, _ *http.Request) {
+	idx := s.getRAGIndex()
+	if idx == nil {
+		writeJSON(w, http.StatusOK, ragHealthResponse{Configured: false})
+		return
+	}
+	em := idx.Embedder()
+	if em == nil {
+		// Should be unreachable — Index is constructed with a non-nil
+		// embedder. Defensive: surface the impossible case rather
+		// than panic.
+		writeJSON(w, http.StatusOK, ragHealthResponse{Configured: true})
+		return
+	}
+	writeJSON(w, http.StatusOK, ragHealthResponse{
+		Configured: true,
+		Model:      em.Model(),
+		Dim:        em.Dim(),
+	})
+}

--- a/internal/gateway/rag_test.go
+++ b/internal/gateway/rag_test.go
@@ -1,0 +1,374 @@
+package gateway
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/euraika-labs/pan-agent/internal/rag"
+	"github.com/euraika-labs/pan-agent/internal/storage"
+)
+
+// Phase 13 WS#13.B — handler tests for /v1/rag/*. The Index logic is
+// covered in internal/rag/index_test.go; these tests pin the HTTP
+// surface contract (status codes, JSON shapes, attached/unattached
+// behaviour, error envelopes).
+
+// gatewayFakeEmbedder mirrors the in-memory fake from internal/rag's
+// tests but lives in the gateway package because Go test files don't
+// share types across packages.
+type gatewayFakeEmbedder struct {
+	model string
+	dim   int
+	calls int64
+}
+
+func (f *gatewayFakeEmbedder) Model() string { return f.model }
+func (f *gatewayFakeEmbedder) Dim() int      { return f.dim }
+func (f *gatewayFakeEmbedder) Embed(_ context.Context, text string) ([]float32, error) {
+	atomic.AddInt64(&f.calls, 1)
+	v := make([]float32, f.dim)
+	var sum int
+	for _, b := range []byte(text) {
+		sum += int(b)
+	}
+	for i := range v {
+		v[i] = float32(sum%(i+7)) / 10.0
+	}
+	return v, nil
+}
+func (f *gatewayFakeEmbedder) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
+	out := make([][]float32, len(texts))
+	for i, t := range texts {
+		v, _ := f.Embed(ctx, t)
+		out[i] = v
+	}
+	return out, nil
+}
+
+// attachIndex builds an Index over a real *storage.DB and attaches it
+// to the server. Returns the embedder so tests can read its call count.
+func attachIndex(t *testing.T, srv *Server) *gatewayFakeEmbedder {
+	t.Helper()
+	em := &gatewayFakeEmbedder{model: "test-model", dim: 4}
+	idx, err := rag.NewIndex(em, srv.db)
+	if err != nil {
+		t.Fatalf("NewIndex: %v", err)
+	}
+	srv.AttachRAGIndex(idx)
+	return em
+}
+
+// ---------------------------------------------------------------------------
+// /v1/rag/health
+// ---------------------------------------------------------------------------
+
+func TestRAGHealth_Unconfigured(t *testing.T) {
+	srv := setupTestServer(t)
+	mux := http.NewServeMux()
+	srv.registerRoutes(mux)
+
+	req := httptest.NewRequest("GET", "/v1/rag/health", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var resp ragHealthResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Configured {
+		t.Error("expected configured=false on fresh server")
+	}
+}
+
+func TestRAGHealth_Configured(t *testing.T) {
+	srv := setupTestServer(t)
+	em := attachIndex(t, srv)
+	mux := http.NewServeMux()
+	srv.registerRoutes(mux)
+
+	req := httptest.NewRequest("GET", "/v1/rag/health", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var resp ragHealthResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if !resp.Configured {
+		t.Error("expected configured=true after AttachRAGIndex")
+	}
+	if resp.Model != em.model {
+		t.Errorf("Model = %q, want %q", resp.Model, em.model)
+	}
+	if resp.Dim != em.dim {
+		t.Errorf("Dim = %d, want %d", resp.Dim, em.dim)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// /v1/rag/index
+// ---------------------------------------------------------------------------
+
+func TestRAGIndex_Unattached_503(t *testing.T) {
+	srv := setupTestServer(t)
+	mux := http.NewServeMux()
+	srv.registerRoutes(mux)
+
+	body := `{"source":"msg","source_id":"x","text":"hello"}`
+	req := httptest.NewRequest("POST", "/v1/rag/index", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", w.Code)
+	}
+	var apiErr APIError
+	_ = json.Unmarshal(w.Body.Bytes(), &apiErr)
+	if apiErr.Code != "rag_unavailable" {
+		t.Errorf("code = %q, want rag_unavailable", apiErr.Code)
+	}
+}
+
+func TestRAGIndex_HappyPath(t *testing.T) {
+	srv := setupTestServer(t)
+	em := attachIndex(t, srv)
+	mux := http.NewServeMux()
+	srv.registerRoutes(mux)
+
+	body := `{"source":"msg","source_id":"id-1","session_id":"sess-1","text":"hello world"}`
+	req := httptest.NewRequest("POST", "/v1/rag/index", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var resp ragIndexResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Cached {
+		t.Error("first index call: expected Cached=false")
+	}
+	if resp.Embedding == nil {
+		t.Fatal("expected embedding in response")
+	}
+	if resp.Embedding.Source != "msg" || resp.Embedding.SourceID != "id-1" {
+		t.Errorf("embedding metadata wrong: %+v", resp.Embedding)
+	}
+	if resp.Embedding.SessionID != "sess-1" {
+		t.Errorf("session_id = %q, want sess-1", resp.Embedding.SessionID)
+	}
+	if em.calls != 1 {
+		t.Errorf("embedder calls = %d, want 1", em.calls)
+	}
+}
+
+func TestRAGIndex_CacheHit(t *testing.T) {
+	srv := setupTestServer(t)
+	em := attachIndex(t, srv)
+	mux := http.NewServeMux()
+	srv.registerRoutes(mux)
+
+	// First request → miss.
+	body := `{"source":"msg","source_id":"id-1","session_id":"s","text":"shared"}`
+	req := httptest.NewRequest("POST", "/v1/rag/index", bytes.NewBufferString(body))
+	mux.ServeHTTP(httptest.NewRecorder(), req)
+
+	// Second request, different source_id, SAME text → cache hit.
+	body2 := `{"source":"msg","source_id":"id-2","session_id":"s","text":"shared"}`
+	req2 := httptest.NewRequest("POST", "/v1/rag/index", bytes.NewBufferString(body2))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req2)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var resp ragIndexResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if !resp.Cached {
+		t.Errorf("expected Cached=true on duplicate text")
+	}
+	if em.calls != 1 {
+		t.Errorf("embedder called %d times, expected 1 (cache miss only)", em.calls)
+	}
+}
+
+func TestRAGIndex_InvalidJSON(t *testing.T) {
+	srv := setupTestServer(t)
+	attachIndex(t, srv)
+	mux := http.NewServeMux()
+	srv.registerRoutes(mux)
+
+	req := httptest.NewRequest("POST", "/v1/rag/index", bytes.NewBufferString("{not json"))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestRAGIndex_ValidationError(t *testing.T) {
+	srv := setupTestServer(t)
+	attachIndex(t, srv)
+	mux := http.NewServeMux()
+	srv.registerRoutes(mux)
+
+	// Missing source.
+	body := `{"source_id":"x","text":"t"}`
+	req := httptest.NewRequest("POST", "/v1/rag/index", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+	var apiErr APIError
+	_ = json.Unmarshal(w.Body.Bytes(), &apiErr)
+	if apiErr.Code != "index_failed" {
+		t.Errorf("code = %q, want index_failed", apiErr.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// /v1/rag/search
+// ---------------------------------------------------------------------------
+
+func TestRAGSearch_Unattached_503(t *testing.T) {
+	srv := setupTestServer(t)
+	mux := http.NewServeMux()
+	srv.registerRoutes(mux)
+
+	body := `{"query":"q","session_id":"s"}`
+	req := httptest.NewRequest("POST", "/v1/rag/search", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", w.Code)
+	}
+}
+
+func TestRAGSearch_HappyPath(t *testing.T) {
+	srv := setupTestServer(t)
+	attachIndex(t, srv)
+	mux := http.NewServeMux()
+	srv.registerRoutes(mux)
+
+	// Seed via index endpoint.
+	for i, txt := range []string{"alpha", "beta", "gamma"} {
+		body := `{"source":"msg","source_id":"id-` + string(rune('a'+i)) +
+			`","session_id":"s","text":"` + txt + `"}`
+		req := httptest.NewRequest("POST", "/v1/rag/index", bytes.NewBufferString(body))
+		mux.ServeHTTP(httptest.NewRecorder(), req)
+	}
+
+	body := `{"query":"alpha","session_id":"s","k":2}`
+	req := httptest.NewRequest("POST", "/v1/rag/search", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var resp ragSearchResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Hits) > 2 {
+		t.Errorf("len = %d, K=2 not respected", len(resp.Hits))
+	}
+	for i, h := range resp.Hits {
+		if h.Embedding == nil {
+			t.Errorf("hit[%d] missing embedding", i)
+		}
+	}
+}
+
+func TestRAGSearch_ValidationError(t *testing.T) {
+	srv := setupTestServer(t)
+	attachIndex(t, srv)
+	mux := http.NewServeMux()
+	srv.registerRoutes(mux)
+
+	body := `{"session_id":"s"}` // missing query
+	req := httptest.NewRequest("POST", "/v1/rag/search", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DELETE /v1/rag/sessions/{id}/embeddings
+// ---------------------------------------------------------------------------
+
+func TestRAGDeleteSession_NoAttachmentNeeded(t *testing.T) {
+	srv := setupTestServer(t)
+	mux := http.NewServeMux()
+	srv.registerRoutes(mux)
+
+	// Even without an attached Index, the delete works against storage.
+	req := httptest.NewRequest("DELETE", "/v1/rag/sessions/sess-empty/embeddings", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var resp ragDeleteResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Deleted != 0 {
+		t.Errorf("deleted = %d, want 0 on empty session", resp.Deleted)
+	}
+}
+
+func TestRAGDeleteSession_RemovesRows(t *testing.T) {
+	srv := setupTestServer(t)
+	attachIndex(t, srv)
+	mux := http.NewServeMux()
+	srv.registerRoutes(mux)
+
+	for i, txt := range []string{"one", "two"} {
+		body := `{"source":"msg","source_id":"id-` + string(rune('a'+i)) +
+			`","session_id":"sess-X","text":"` + txt + `"}`
+		req := httptest.NewRequest("POST", "/v1/rag/index", bytes.NewBufferString(body))
+		mux.ServeHTTP(httptest.NewRecorder(), req)
+	}
+
+	req := httptest.NewRequest("DELETE", "/v1/rag/sessions/sess-X/embeddings", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var resp ragDeleteResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Deleted != 2 {
+		t.Errorf("deleted = %d, want 2", resp.Deleted)
+	}
+
+	// Confirm via storage layer that the rows are gone.
+	rest, err := srv.db.ListEmbeddingsBySession("sess-X")
+	if err != nil {
+		t.Fatalf("ListEmbeddingsBySession: %v", err)
+	}
+	if len(rest) != 0 {
+		t.Errorf("after delete, %d rows remain", len(rest))
+	}
+	// Sanity: storage error sentinel still importable.
+	_ = storage.ErrEmbeddingNotFound
+}

--- a/internal/gateway/routes.go
+++ b/internal/gateway/routes.go
@@ -165,6 +165,16 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /v1/recovery/undo/{receiptID}", s.handleRecoveryUndo)
 	mux.HandleFunc("GET /v1/recovery/diff/{receiptID}", s.handleRecoveryDiff)
 
+	// -------------------------------------------------------------------- rag
+	// Phase 13 WS#13.B — semantic-search index over chat history.
+	// Endpoints 503 when no embedder has been attached via
+	// Server.AttachRAGIndex; the desktop UI surfaces a setup hint
+	// based on /v1/rag/health's "configured" flag.
+	mux.HandleFunc("POST /v1/rag/index", s.handleRAGIndex)
+	mux.HandleFunc("POST /v1/rag/search", s.handleRAGSearch)
+	mux.HandleFunc("DELETE /v1/rag/sessions/{id}/embeddings", s.handleRAGSessionEmbeddingsDelete)
+	mux.HandleFunc("GET /v1/rag/health", s.handleRAGHealth)
+
 	// ----------------------------------------------------------------- health
 	mux.HandleFunc("GET /v1/health", s.handleHealth)
 

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/euraika-labs/pan-agent/internal/config"
 	"github.com/euraika-labs/pan-agent/internal/llm"
 	"github.com/euraika-labs/pan-agent/internal/paths"
+	"github.com/euraika-labs/pan-agent/internal/rag"
 	"github.com/euraika-labs/pan-agent/internal/recovery"
 	"github.com/euraika-labs/pan-agent/internal/storage"
 )
@@ -53,6 +54,12 @@ type Server struct {
 	// recoveryOnce lazily initialises recoveryH on first request.
 	recoveryOnce sync.Once
 	recoveryH    *recovery.Handler
+
+	// ragMu guards ragIndex. Phase 13 WS#13.B — the index is wired in
+	// after construction (so the desktop UI can hot-swap embedders);
+	// nil means "not configured" and handlers respond 503.
+	ragMu    sync.RWMutex
+	ragIndex *rag.Index
 }
 
 // getLLMClient returns the current LLM client under a read lock.

--- a/internal/rag/index.go
+++ b/internal/rag/index.go
@@ -84,6 +84,13 @@ type Index struct {
 	store    Store
 }
 
+// Embedder returns the embedder this Index was constructed with.
+// Exposed for HTTP introspection (e.g. /v1/rag/health reporting the
+// active model + dim). Callers should treat the returned interface
+// as read-only — calling Embed directly bypasses the content-hash
+// gate, which is almost never what you want.
+func (idx *Index) Embedder() Embedder { return idx.embedder }
+
 // NewIndex wires the two collaborators. Both must be non-nil — Index
 // has nothing useful to do without an embedder or a store.
 func NewIndex(embedder Embedder, store Store) (*Index, error) {

--- a/scripts/openapi-exempt.txt
+++ b/scripts/openapi-exempt.txt
@@ -73,3 +73,11 @@
 # --- tools registry (list + per-tool toggle)
 /v1/tools
 /v1/tools/{key}
+
+# --- rag: Phase 13 WS#13.B substrate. Documenting the JSON shapes is
+# deferred until chat-loop integration ships; the request/response
+# types are still in flux while the embedder-config UX lands.
+/v1/rag/index
+/v1/rag/search
+/v1/rag/sessions/{id}/embeddings
+/v1/rag/health


### PR DESCRIPTION
## Summary

Exposes the WS#13.B index (#42 #43 #44) over four HTTP routes so the desktop UI + any HTTP client can manually index, search, and purge embeddings:

| Method | Path | Purpose |
|---|---|---|
| POST | \`/v1/rag/index\` | Upsert — text in, \`{cached, embedding}\` out |
| POST | \`/v1/rag/search\` | Top-K cosine, session-scoped |
| DELETE | \`/v1/rag/sessions/{id}/embeddings\` | Purge a session |
| GET | \`/v1/rag/health\` | \`{configured, model, dim}\` |

## Lazy attachment

\`Server.AttachRAGIndex(idx)\` wires a configured \`rag.Index\` after \`New\` so the desktop UI can hot-swap embedders without restarting the gateway. Until something attaches:

- \`/v1/rag/index\` and \`/v1/rag/search\` → 503 with code \`rag_unavailable\`
- \`/v1/rag/health\` → 200 + \`{\"configured\": false}\` (UI surfaces a setup hint)
- \`DELETE /v1/rag/sessions/{id}/embeddings\` still works (storage-backed, embedder-free)

## Notes

- \`ragEmbeddingDTO\` is metadata-only; vector bytes deliberately omitted (a 384-dim vector is 1.5KB per row).
- Added \`Embedder()\` accessor on \`rag.Index\` so the health endpoint reads \`Model()\` / \`Dim()\` without exposing the concrete type.
- \`scripts/openapi-exempt.txt\` adds four entries with a one-line justification (shapes in flux until embedder-config UX lands). \`verify-api: 68 routes, 20 documented, 48 exempt\`.

## Test plan

- [x] \`/v1/rag/health\` unattached + configured (Model + Dim reported)
- [x] \`/v1/rag/index\` unattached → 503 with \`rag_unavailable\` code
- [x] \`/v1/rag/index\` happy path: cache miss → embedder called once
- [x] \`/v1/rag/index\` cache hit: same text under same model → no embed
- [x] \`/v1/rag/index\` invalid JSON, validation error
- [x] \`/v1/rag/search\` unattached → 503
- [x] \`/v1/rag/search\` happy path with K cap
- [x] \`/v1/rag/search\` validation
- [x] DELETE works without an attached Index (storage-backed)
- [x] DELETE removes seeded rows + \`ListEmbeddingsBySession\` round-trip
- [x] \`go test ./...\` — 498/498 pass
- [x] \`bash scripts/verify-api.sh\` — green
- [x] \`golangci-lint run ./internal/gateway/ ./internal/rag/\` — 0 issues

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)