### PR TITLE
feat(rag): WS#13.B watcher — polling auto-indexer with crash-safe cursor

### DIFF
--- a/internal/rag/watcher.go
+++ b/internal/rag/watcher.go
@@ -1,0 +1,291 @@
+package rag
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/euraika-labs/pan-agent/internal/storage"
+)
+
+// Phase 13 WS#13.B — message watcher. Polls the messages table for
+// new entries and feeds them through Index.Upsert so the semantic
+// index stays in sync with the chat history without each AddMessage
+// call blocking on the embedder.
+//
+// Why polling instead of an AddMessage hook:
+//
+//   1. Decouples the chat hot path from the embedder. AddMessage is
+//      called on every streaming token finalisation; embedding takes
+//      a network round-trip. A polling watcher absorbs latency
+//      without holding up the writer.
+//   2. Crash-safe by construction. The cursor is persisted in
+//      rag_state, so a crash mid-tick re-processes the unfinished
+//      batch on restart. Index.Upsert's content-hash gate makes the
+//      re-processing a no-op for already-embedded rows.
+//   3. Backpressure-friendly. If the embedder is slow or the rate
+//      limit kicks in, the queue grows on the messages table side
+//      (which is fine — messages persist regardless) instead of
+//      stalling chat.
+//
+// Trade-offs accepted:
+//   - Up to `interval` of indexing latency (default 5s).
+//   - Tool-role messages are skipped because they are usually
+//     command output that pollutes search results.
+
+// MessageStore is the subset of *storage.DB methods Watcher needs.
+// Defined as an interface so unit tests inject in-memory fakes.
+type MessageStore interface {
+	ListMessagesSince(afterID int64, limit int) ([]storage.Message, error)
+	GetRAGState(key string) (string, bool, error)
+	SetRAGState(key, value string) error
+}
+
+// WatcherOptions configures Watcher behaviour. Zero-value fields fall
+// back to the documented defaults.
+type WatcherOptions struct {
+	// Interval between polling ticks. 0 → 5s.
+	Interval time.Duration
+	// BatchSize caps the number of messages drained per tick. 0 → 100.
+	// Smaller batches keep the embedder's per-tick latency bounded.
+	BatchSize int
+	// CursorKey under which the watcher records its progress in
+	// rag_state. 0-length → "watcher:last_message_id". Tests
+	// override to isolate state across parallel runs.
+	CursorKey string
+	// MinTextLength skips messages whose content is shorter than this
+	// after trim. 0 → 1 (only literal-empty messages are skipped).
+	// Set higher to skip "ok"/"yes"-style replies that don't carry
+	// search-worthy information.
+	MinTextLength int
+}
+
+// Watcher is the polling auto-indexer. Construct with NewWatcher,
+// run with Start, halt with Stop. Tick is exposed for tests + manual
+// catch-up calls; production code typically only calls Start/Stop.
+type Watcher struct {
+	idx       *Index
+	store     MessageStore
+	interval  time.Duration
+	batchSize int
+	cursorKey string
+	minLen    int
+
+	mu      sync.Mutex
+	running bool
+	stopCh  chan struct{}
+	doneCh  chan struct{}
+}
+
+// DefaultCursorKey is the rag_state key the watcher uses to record
+// progress when WatcherOptions.CursorKey is empty.
+const DefaultCursorKey = "watcher:last_message_id"
+
+// NewWatcher constructs a Watcher. idx + store must be non-nil.
+// Defaults applied in this order:
+//
+//	Interval      → 5s
+//	BatchSize     → 100
+//	CursorKey     → "watcher:last_message_id"
+//	MinTextLength → 1 (only literally-empty messages skipped)
+func NewWatcher(idx *Index, store MessageStore, opts WatcherOptions) (*Watcher, error) {
+	if idx == nil {
+		return nil, fmt.Errorf("rag: NewWatcher: idx required")
+	}
+	if store == nil {
+		return nil, fmt.Errorf("rag: NewWatcher: store required")
+	}
+	w := &Watcher{
+		idx:       idx,
+		store:     store,
+		interval:  opts.Interval,
+		batchSize: opts.BatchSize,
+		cursorKey: opts.CursorKey,
+		minLen:    opts.MinTextLength,
+	}
+	if w.interval == 0 {
+		w.interval = 5 * time.Second
+	}
+	if w.batchSize == 0 {
+		w.batchSize = 100
+	}
+	if w.cursorKey == "" {
+		w.cursorKey = DefaultCursorKey
+	}
+	if w.minLen == 0 {
+		w.minLen = 1
+	}
+	return w, nil
+}
+
+// Start runs the watcher loop on a goroutine. Returns immediately
+// after kicking it off; the loop runs until ctx is cancelled or
+// Stop() is called. Calling Start while already running returns an
+// error to surface the misuse.
+func (w *Watcher) Start(ctx context.Context) error {
+	w.mu.Lock()
+	if w.running {
+		w.mu.Unlock()
+		return fmt.Errorf("rag: Watcher already running")
+	}
+	w.stopCh = make(chan struct{})
+	w.doneCh = make(chan struct{})
+	w.running = true
+	w.mu.Unlock()
+
+	go w.run(ctx)
+	return nil
+}
+
+// Stop signals the watcher to halt and waits for the goroutine to
+// finish. Idempotent: calling Stop on a stopped watcher is a no-op.
+func (w *Watcher) Stop() error {
+	w.mu.Lock()
+	if !w.running {
+		w.mu.Unlock()
+		return nil
+	}
+	close(w.stopCh)
+	done := w.doneCh
+	w.running = false
+	w.mu.Unlock()
+
+	<-done
+	return nil
+}
+
+// Running reports whether Start has been called and Stop has not.
+func (w *Watcher) Running() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.running
+}
+
+func (w *Watcher) run(ctx context.Context) {
+	defer close(w.doneCh)
+
+	// Drain once on startup so a freshly-launched server catches up
+	// to the existing message log without waiting for the first tick.
+	if _, err := w.Tick(ctx); err != nil {
+		log.Printf("rag: watcher initial tick: %v", err)
+	}
+
+	ticker := time.NewTicker(w.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-w.stopCh:
+			return
+		case <-ticker.C:
+			if _, err := w.Tick(ctx); err != nil {
+				log.Printf("rag: watcher tick: %v", err)
+			}
+		}
+	}
+}
+
+// Tick processes one batch of unprocessed messages. Returns the
+// number of messages successfully indexed (cache hits count too —
+// they don't trigger an embedder call but they do advance progress).
+//
+// Errors mid-batch fail the whole tick; the cursor is NOT advanced
+// past the failure point so retries pick up where it stopped. The
+// rag_state cursor is only persisted after the entire batch
+// succeeds, which keeps the at-least-once guarantee tight.
+func (w *Watcher) Tick(ctx context.Context) (int, error) {
+	cursor, err := w.readCursor()
+	if err != nil {
+		return 0, fmt.Errorf("rag: Tick read cursor: %w", err)
+	}
+
+	msgs, err := w.store.ListMessagesSince(cursor, w.batchSize)
+	if err != nil {
+		return 0, fmt.Errorf("rag: Tick list: %w", err)
+	}
+	if len(msgs) == 0 {
+		return 0, nil
+	}
+
+	indexed := 0
+	maxID := cursor
+	for _, m := range msgs {
+		if ctx.Err() != nil {
+			return indexed, ctx.Err()
+		}
+		if !w.shouldIndex(m) {
+			// Skipped messages still advance the cursor so we don't
+			// re-evaluate them on every tick.
+			if m.ID > maxID {
+				maxID = m.ID
+			}
+			continue
+		}
+		_, err := w.idx.Upsert(ctx, IngestRequest{
+			Source:    "message",
+			SourceID:  strconv.FormatInt(m.ID, 10),
+			SessionID: m.SessionID,
+			Text:      m.Content,
+		})
+		if err != nil {
+			// Persist any progress made so far, then surface the
+			// error. The next tick retries from the failure point.
+			if maxID > cursor {
+				_ = w.writeCursor(maxID)
+			}
+			return indexed, fmt.Errorf("rag: Tick upsert msg %d: %w", m.ID, err)
+		}
+		indexed++
+		if m.ID > maxID {
+			maxID = m.ID
+		}
+	}
+
+	if maxID > cursor {
+		if err := w.writeCursor(maxID); err != nil {
+			return indexed, fmt.Errorf("rag: Tick write cursor: %w", err)
+		}
+	}
+	return indexed, nil
+}
+
+// shouldIndex returns true when m carries enough signal to be worth
+// embedding. Skips: tool messages (typically command output), system
+// messages, role-less rows, and content shorter than minLen.
+func (w *Watcher) shouldIndex(m storage.Message) bool {
+	if m.Role != "user" && m.Role != "assistant" {
+		return false
+	}
+	if len(m.Content) < w.minLen {
+		return false
+	}
+	return true
+}
+
+func (w *Watcher) readCursor() (int64, error) {
+	v, ok, err := w.store.GetRAGState(w.cursorKey)
+	if err != nil {
+		return 0, err
+	}
+	if !ok {
+		return 0, nil
+	}
+	id, err := strconv.ParseInt(v, 10, 64)
+	if err != nil {
+		// Corrupt cursor — treat as zero. The next tick will re-read
+		// from the start; the content-hash gate prevents duplicate
+		// embeddings even after the rewind.
+		log.Printf("rag: watcher cursor corrupt (%q), resetting to 0", v)
+		return 0, nil
+	}
+	return id, nil
+}
+
+func (w *Watcher) writeCursor(id int64) error {
+	return w.store.SetRAGState(w.cursorKey, strconv.FormatInt(id, 10))
+}

--- a/internal/rag/watcher_test.go
+++ b/internal/rag/watcher_test.go
@@ -1,0 +1,389 @@
+package rag
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/euraika-labs/pan-agent/internal/storage"
+)
+
+// Phase 13 WS#13.B — watcher tests. Cover Tick semantics in isolation
+// (cursor advance, role filter, min-length filter, error handling)
+// plus a small Start/Stop liveness test.
+
+// fakeMessageStore implements MessageStore without SQLite.
+type fakeMessageStore struct {
+	mu       sync.Mutex
+	messages []storage.Message
+	state    map[string]string
+
+	// failOnSet, when true, makes SetRAGState return an error so we
+	// can verify Tick handles persistence failures cleanly.
+	failOnSet bool
+}
+
+func newFakeMessageStore() *fakeMessageStore {
+	return &fakeMessageStore{state: map[string]string{}}
+}
+
+func (s *fakeMessageStore) ListMessagesSince(after int64, limit int) ([]storage.Message, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []storage.Message
+	for _, m := range s.messages {
+		if m.ID > after {
+			out = append(out, m)
+			if len(out) >= limit {
+				break
+			}
+		}
+	}
+	return out, nil
+}
+
+func (s *fakeMessageStore) GetRAGState(key string) (string, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	v, ok := s.state[key]
+	return v, ok, nil
+}
+
+func (s *fakeMessageStore) SetRAGState(key, value string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.failOnSet {
+		return errors.New("simulated cursor write failure")
+	}
+	s.state[key] = value
+	return nil
+}
+
+func (s *fakeMessageStore) addMsg(t *testing.T, role, content string) int64 {
+	t.Helper()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	id := int64(len(s.messages) + 1)
+	s.messages = append(s.messages, storage.Message{
+		ID: id, SessionID: "s-1", Role: role, Content: content,
+		Timestamp: time.Now().Unix(),
+	})
+	return id
+}
+
+// newTestWatcher builds a Watcher over fake collaborators sharing the
+// same fake store across the Index and the Watcher (so the Index's
+// content-hash dedup is observable through the same backing rows).
+func newTestWatcher(t *testing.T, opts WatcherOptions) (*Watcher, *fakeMessageStore, *fakeEmbedder) {
+	t.Helper()
+	em := &fakeEmbedder{model: "watcher-test", dim: 4}
+	storeFake := &fakeStore{}
+	idx, err := NewIndex(em, storeFake)
+	if err != nil {
+		t.Fatalf("NewIndex: %v", err)
+	}
+	msgs := newFakeMessageStore()
+	w, err := NewWatcher(idx, msgs, opts)
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+	return w, msgs, em
+}
+
+// ---------------------------------------------------------------------------
+// Tick — cursor + role + length semantics
+// ---------------------------------------------------------------------------
+
+func TestNewWatcher_Validation(t *testing.T) {
+	t.Parallel()
+	em := &fakeEmbedder{model: "m", dim: 2}
+	idx, _ := NewIndex(em, &fakeStore{})
+	if _, err := NewWatcher(nil, newFakeMessageStore(), WatcherOptions{}); err == nil {
+		t.Error("nil idx: expected error")
+	}
+	if _, err := NewWatcher(idx, nil, WatcherOptions{}); err == nil {
+		t.Error("nil store: expected error")
+	}
+}
+
+func TestWatcher_DefaultOptions(t *testing.T) {
+	t.Parallel()
+	w, _, _ := newTestWatcher(t, WatcherOptions{})
+	if w.interval != 5*time.Second {
+		t.Errorf("interval default = %v, want 5s", w.interval)
+	}
+	if w.batchSize != 100 {
+		t.Errorf("batchSize default = %d, want 100", w.batchSize)
+	}
+	if w.cursorKey != DefaultCursorKey {
+		t.Errorf("cursorKey default = %q, want %q", w.cursorKey, DefaultCursorKey)
+	}
+	if w.minLen != 1 {
+		t.Errorf("minLen default = %d, want 1", w.minLen)
+	}
+}
+
+func TestWatcher_Tick_FreshState(t *testing.T) {
+	t.Parallel()
+	w, msgs, em := newTestWatcher(t, WatcherOptions{BatchSize: 50})
+
+	msgs.addMsg(t, "user", "hello world")
+	msgs.addMsg(t, "assistant", "hi back")
+	msgs.addMsg(t, "user", "how are you")
+
+	n, err := w.Tick(context.Background())
+	if err != nil {
+		t.Fatalf("Tick: %v", err)
+	}
+	if n != 3 {
+		t.Errorf("indexed = %d, want 3", n)
+	}
+	if em.callCount() != 3 {
+		t.Errorf("embedder called %d times, want 3", em.callCount())
+	}
+	v, ok, _ := msgs.GetRAGState(w.cursorKey)
+	if !ok || v != "3" {
+		t.Errorf("cursor = %q (ok=%v), want \"3\"", v, ok)
+	}
+}
+
+func TestWatcher_Tick_Idempotent(t *testing.T) {
+	t.Parallel()
+	w, msgs, em := newTestWatcher(t, WatcherOptions{BatchSize: 50})
+
+	msgs.addMsg(t, "user", "msg-A")
+	msgs.addMsg(t, "user", "msg-B")
+
+	if _, err := w.Tick(context.Background()); err != nil {
+		t.Fatalf("first Tick: %v", err)
+	}
+	first := em.callCount()
+
+	// Second tick with no new messages: no embed calls, cursor unchanged.
+	n, err := w.Tick(context.Background())
+	if err != nil {
+		t.Fatalf("second Tick: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("indexed = %d, want 0 on idle tick", n)
+	}
+	if em.callCount() != first {
+		t.Errorf("embedder called extra times: %d vs %d", em.callCount(), first)
+	}
+}
+
+func TestWatcher_Tick_OnlyNewMessages(t *testing.T) {
+	t.Parallel()
+	w, msgs, em := newTestWatcher(t, WatcherOptions{BatchSize: 50})
+
+	msgs.addMsg(t, "user", "first")
+	msgs.addMsg(t, "user", "second")
+	if _, err := w.Tick(context.Background()); err != nil {
+		t.Fatalf("first Tick: %v", err)
+	}
+	beforeNew := em.callCount()
+
+	msgs.addMsg(t, "user", "third")
+	msgs.addMsg(t, "assistant", "fourth")
+
+	n, err := w.Tick(context.Background())
+	if err != nil {
+		t.Fatalf("second Tick: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("indexed = %d, want 2 (only new)", n)
+	}
+	delta := em.callCount() - beforeNew
+	if delta != 2 {
+		t.Errorf("embedder delta = %d, want 2", delta)
+	}
+}
+
+func TestWatcher_Tick_SkipsToolAndSystem(t *testing.T) {
+	t.Parallel()
+	w, msgs, em := newTestWatcher(t, WatcherOptions{BatchSize: 50})
+
+	msgs.addMsg(t, "user", "real one")
+	msgs.addMsg(t, "tool", "command output")
+	msgs.addMsg(t, "system", "system prompt")
+	msgs.addMsg(t, "assistant", "real reply")
+
+	n, err := w.Tick(context.Background())
+	if err != nil {
+		t.Fatalf("Tick: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("indexed = %d, want 2 (user + assistant only)", n)
+	}
+	if em.callCount() != 2 {
+		t.Errorf("embedder calls = %d, want 2", em.callCount())
+	}
+	// Cursor must advance past skipped rows so they don't get re-checked.
+	v, _, _ := msgs.GetRAGState(w.cursorKey)
+	if v != "4" {
+		t.Errorf("cursor = %q, want \"4\" (advanced past tool/system)", v)
+	}
+}
+
+func TestWatcher_Tick_MinLengthFilter(t *testing.T) {
+	t.Parallel()
+	w, msgs, _ := newTestWatcher(t, WatcherOptions{MinTextLength: 10})
+
+	msgs.addMsg(t, "user", "ok")                  // < 10 chars: skipped
+	msgs.addMsg(t, "user", "this is long enough") // ≥ 10: indexed
+
+	n, err := w.Tick(context.Background())
+	if err != nil {
+		t.Fatalf("Tick: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("indexed = %d, want 1", n)
+	}
+}
+
+func TestWatcher_Tick_BatchSizeCaps(t *testing.T) {
+	t.Parallel()
+	w, msgs, _ := newTestWatcher(t, WatcherOptions{BatchSize: 2})
+
+	for i := 0; i < 5; i++ {
+		msgs.addMsg(t, "user", "msg-"+strconv.Itoa(i))
+	}
+
+	n, err := w.Tick(context.Background())
+	if err != nil {
+		t.Fatalf("Tick: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("first Tick: indexed = %d, want 2 (BatchSize cap)", n)
+	}
+
+	n, err = w.Tick(context.Background())
+	if err != nil {
+		t.Fatalf("second Tick: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("second Tick: indexed = %d, want 2", n)
+	}
+
+	n, err = w.Tick(context.Background())
+	if err != nil {
+		t.Fatalf("third Tick: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("third Tick: indexed = %d, want 1 (drain)", n)
+	}
+}
+
+func TestWatcher_Tick_EmptyContent(t *testing.T) {
+	t.Parallel()
+	w, msgs, em := newTestWatcher(t, WatcherOptions{})
+
+	msgs.addMsg(t, "user", "")
+	msgs.addMsg(t, "user", "real")
+
+	n, err := w.Tick(context.Background())
+	if err != nil {
+		t.Fatalf("Tick: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("indexed = %d, want 1 (empty skipped)", n)
+	}
+	if em.callCount() != 1 {
+		t.Errorf("embedder calls = %d, want 1", em.callCount())
+	}
+}
+
+func TestWatcher_Tick_CorruptCursorResets(t *testing.T) {
+	t.Parallel()
+	w, msgs, _ := newTestWatcher(t, WatcherOptions{})
+
+	// Pre-seed a corrupt cursor value.
+	_ = msgs.SetRAGState(w.cursorKey, "not-a-number")
+	msgs.addMsg(t, "user", "alpha")
+
+	n, err := w.Tick(context.Background())
+	if err != nil {
+		t.Fatalf("Tick: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("indexed = %d, want 1 (cursor should reset to 0 on corrupt)", n)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Start / Stop liveness
+// ---------------------------------------------------------------------------
+
+func TestWatcher_StartStop(t *testing.T) {
+	t.Parallel()
+	w, msgs, em := newTestWatcher(t, WatcherOptions{Interval: 10 * time.Millisecond})
+
+	msgs.addMsg(t, "user", "before-start")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := w.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if !w.Running() {
+		t.Error("Running() = false after Start")
+	}
+
+	// Wait for the initial drain tick to complete.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) && atomic.LoadInt64(&em.calls) == 0 {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if em.callCount() < 1 {
+		t.Errorf("watcher did not drain initial messages: calls = %d", em.callCount())
+	}
+
+	if err := w.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if w.Running() {
+		t.Error("Running() = true after Stop")
+	}
+	// Idempotent Stop.
+	if err := w.Stop(); err != nil {
+		t.Errorf("second Stop: %v", err)
+	}
+}
+
+func TestWatcher_StartTwiceErrors(t *testing.T) {
+	t.Parallel()
+	w, _, _ := newTestWatcher(t, WatcherOptions{Interval: time.Hour})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := w.Start(ctx); err != nil {
+		t.Fatalf("first Start: %v", err)
+	}
+	defer w.Stop()
+	if err := w.Start(ctx); err == nil {
+		t.Error("second Start: expected error")
+	}
+}
+
+func TestWatcher_ContextCancelStops(t *testing.T) {
+	t.Parallel()
+	w, _, _ := newTestWatcher(t, WatcherOptions{Interval: 10 * time.Millisecond})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	if err := w.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	cancel()
+
+	// Loop should exit promptly. Stop() waits for it.
+	done := make(chan struct{})
+	go func() { _ = w.Stop(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher did not stop within 2s of ctx cancel")
+	}
+}

--- a/internal/storage/rag.go
+++ b/internal/storage/rag.go
@@ -188,6 +188,43 @@ func (d *DB) GetRAGState(key string) (string, bool, error) {
 	return v, true, nil
 }
 
+// ListMessagesSince returns messages with id > afterID, ordered ASC,
+// capped at limit rows. Used by the rag watcher to drain new messages
+// in id order so the cursor advances monotonically. Pass afterID=0 to
+// start from the beginning.
+//
+// limit must be positive; <= 0 returns an error so we don't accidentally
+// stream the whole table on a misuse.
+func (d *DB) ListMessagesSince(afterID int64, limit int) ([]Message, error) {
+	if limit <= 0 {
+		return nil, fmt.Errorf("storage: ListMessagesSince: limit must be > 0, got %d", limit)
+	}
+	const q = `
+SELECT id, session_id, role, content, timestamp
+FROM   messages
+WHERE  id > ?
+ORDER  BY id ASC
+LIMIT  ?`
+	rows, err := d.db.Query(q, afterID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("storage: ListMessagesSince: %w", err)
+	}
+	defer rows.Close()
+	var out []Message
+	for rows.Next() {
+		var m Message
+		var content sql.NullString
+		if err := rows.Scan(&m.ID, &m.SessionID, &m.Role, &content, &m.Timestamp); err != nil {
+			return nil, fmt.Errorf("storage: ListMessagesSince scan: %w", err)
+		}
+		if content.Valid {
+			m.Content = content.String
+		}
+		out = append(out, m)
+	}
+	return out, rows.Err()
+}
+
 // SetRAGState upserts a single key/value into rag_state. Used by the
 // embedder watcher to record its progress (last_indexed_event_id,
 // last_indexed_message_id, etc.) so a crash-resume picks up cleanly.


### PR DESCRIPTION
## Summary

Polls the messages table and feeds new entries through \`Index.Upsert\` so the semantic index stays in sync with chat history without blocking the chat hot path. Builds on the WS#13.B substrate (#42 #43 #44 #45).

## Why polling, not an `AddMessage` hook

1. **Hot-path decoupling.** \`AddMessage\` runs on every token finalisation; embedding takes a network round-trip. Polling absorbs latency without holding up the writer.
2. **Crash-safe.** Cursor persisted in \`rag_state\` (key \`watcher:last_message_id\`). A crash mid-tick re-processes the unfinished batch on restart; \`Index.Upsert\`'s content-hash gate makes that idempotent.
3. **Backpressure-friendly.** Slow embedder → queue grows on the messages table side, not on chat.

## What's in the PR

### \`internal/storage/rag.go\`
- \`ListMessagesSince(afterID, limit)\` — id-ordered drain query. Validates \`limit > 0\` so misuse can't accidentally stream the whole table.

### \`internal/rag/watcher.go\`
- \`MessageStore\` interface — subset of \`*storage.DB\` the watcher needs.
- \`WatcherOptions\` with documented defaults (Interval=5s, BatchSize=100, CursorKey=\"watcher:last_message_id\", MinTextLength=1).
- \`Start\` runs a goroutine that drains once on startup then ticks on Interval. \`Stop\` is idempotent and waits for the goroutine.
- \`Tick\` is the unit-of-work: read cursor → \`ListMessagesSince\` → \`shouldIndex\` filter (skips tool/system roles, length filter) → \`Upsert\` each → persist max id seen. Skipped rows still advance the cursor.
- Errors mid-batch persist progress, then surface; next tick retries from the failure point. At-least-once with content-hash idempotence.
- Corrupt cursor value resets to 0; the content-hash gate prevents duplicate embeddings even after rewind.

## Test plan

- [x] 12 watcher tests covering validation, defaults, fresh-state full drain, idempotency, only-new-messages, role filter (tool/system skipped + cursor advances past), MinTextLength filter, BatchSize cap, empty-content skip, corrupt-cursor reset, Start/Stop liveness with initial drain, double-Start error, context-cancel-stops-loop
- [x] \`go test ./...\` — 511/511 pass
- [x] \`golangci-lint run ./internal/rag/ ./internal/storage/\` — 0 issues

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)