### PR TITLE
feat(marketplace): WS#13.C bundle → skill extractor

### DIFF
--- a/internal/marketplace/skill_extract.go
+++ b/internal/marketplace/skill_extract.go
@@ -1,0 +1,199 @@
+package marketplace
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// Phase 13 WS#13.C — bundle → skill contents.
+//
+// A verified Bundle is just a directory tree the producer signed. The
+// install pipeline needs to translate that into something the existing
+// reviewer-agent queue understands: one SKILL.md (with frontmatter)
+// plus zero or more supporting files.
+//
+// ExtractSkill is the boundary. Given a *Bundle, it:
+//
+//   1. Locates the SKILL.md file (must be in the manifest).
+//   2. Parses the frontmatter to pull out name + category +
+//      description (the same fields skills.CreateProposal needs).
+//   3. Reads every other manifest-declared file as a supporting file.
+//   4. Returns a SkillContents struct ready to hand to the next slice
+//      that will call into internal/skills.
+//
+// We deliberately don't import internal/skills here — that boundary
+// is owned by the next slice. Keeping the marketplace package
+// skill-package-free makes both sides independently testable + lets
+// the same parser feed into a future "preview manifest before
+// install" UI flow that doesn't touch the proposal queue.
+
+// SkillFilename is the conventional path to the skill's main file.
+// Hardcoded so a producer can't rename it to slip the parser.
+const SkillFilename = "SKILL.md"
+
+// MinDescriptionLen / MaxDescriptionLen / MaxSkillContentLen mirror
+// the bounds the existing skill manager enforces. Surfacing them
+// here lets the marketplace reject malformed bundles BEFORE the
+// reviewer pipeline sees them so error messages stay close to the
+// producer.
+const (
+	MaxSkillNameLen        = 63
+	MinSkillDescriptionLen = 1
+	MaxSkillDescriptionLen = 512
+	MaxSkillContentLen     = 256 * 1024 // 256KB cap on SKILL.md
+	MaxSupportingFileLen   = 1024 * 1024
+)
+
+// nameRe mirrors paths.ValidateProfile + skills.ValidateName: ASCII
+// alphanumeric, underscore, hyphen, length 1..63, must start with
+// alphanumeric. Marketplace bundles that pass this same shape can
+// be staged without a second validation pass on the skills side.
+var nameRe = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]{0,62}$`)
+
+// SkillContents is the parsed view a Bundle yields up to the
+// install pipeline. Content is the raw SKILL.md bytes (frontmatter
+// included, since the existing reviewer agent re-parses); Supporting
+// holds every other manifest-listed file by its bundle-relative path.
+type SkillContents struct {
+	Name        string
+	Category    string
+	Description string
+	Content     string            // raw SKILL.md bytes (frontmatter included)
+	Supporting  map[string][]byte // bundle-relative path → bytes
+}
+
+// ExtractSkill walks b's manifest, locates SKILL.md, parses
+// frontmatter, and reads every other declared file. Returns
+// ErrBundleInvalid-wrapped errors for shape problems so the install
+// caller can present a unified "bundle rejected" UX.
+//
+// Pre-condition: b was returned from LoadBundle (signature + hashes
+// already validated). ExtractSkill re-reads the files but trusts the
+// hash check that already ran — no fresh sha256 pass.
+func ExtractSkill(b *Bundle) (*SkillContents, error) {
+	if b == nil {
+		return nil, fmt.Errorf("%w: nil bundle", ErrBundleInvalid)
+	}
+
+	// Find SKILL.md in the manifest.
+	var skillEntry *ManifestFile
+	for i := range b.Manifest.Files {
+		if b.Manifest.Files[i].Path == SkillFilename {
+			skillEntry = &b.Manifest.Files[i]
+			break
+		}
+	}
+	if skillEntry == nil {
+		return nil, fmt.Errorf("%w: bundle missing %s", ErrBundleInvalid, SkillFilename)
+	}
+	if skillEntry.Size > MaxSkillContentLen {
+		return nil, fmt.Errorf("%w: %s exceeds %d bytes",
+			ErrBundleInvalid, SkillFilename, MaxSkillContentLen)
+	}
+
+	skillBytes, err := os.ReadFile(filepath.Join(b.Root, SkillFilename)) //nolint:gosec // path validated by LoadBundle
+	if err != nil {
+		return nil, fmt.Errorf("%w: read %s: %v", ErrBundleInvalid, SkillFilename, err)
+	}
+	skillStr := string(skillBytes)
+
+	// Pull required fields from frontmatter.
+	name := frontmatterField(skillStr, "name")
+	if name == "" {
+		// Fall back to manifest's name if frontmatter omits it. Helpful
+		// for hand-authored bundles.
+		name = b.Manifest.Name
+	}
+	if !nameRe.MatchString(name) {
+		return nil, fmt.Errorf("%w: name %q is invalid (alphanumeric/underscore/hyphen, max %d chars)",
+			ErrBundleInvalid, name, MaxSkillNameLen)
+	}
+
+	description := frontmatterField(skillStr, "description")
+	if description == "" {
+		description = b.Manifest.Description
+	}
+	if len(description) < MinSkillDescriptionLen {
+		return nil, fmt.Errorf("%w: description is empty", ErrBundleInvalid)
+	}
+	if len(description) > MaxSkillDescriptionLen {
+		return nil, fmt.Errorf("%w: description exceeds %d chars",
+			ErrBundleInvalid, MaxSkillDescriptionLen)
+	}
+
+	category := frontmatterField(skillStr, "category")
+	if category == "" {
+		// Marketplace bundles MUST declare a category — there's no
+		// safe default; categorisation drives where the skill lands
+		// in the UI tree.
+		return nil, fmt.Errorf("%w: SKILL.md frontmatter missing category", ErrBundleInvalid)
+	}
+	if !nameRe.MatchString(category) {
+		return nil, fmt.Errorf("%w: category %q is invalid", ErrBundleInvalid, category)
+	}
+
+	// Read every other declared file as supporting.
+	supporting := map[string][]byte{}
+	for _, f := range b.Manifest.Files {
+		if f.Path == SkillFilename {
+			continue
+		}
+		if f.Size > MaxSupportingFileLen {
+			return nil, fmt.Errorf("%w: supporting file %q exceeds %d bytes",
+				ErrBundleInvalid, f.Path, MaxSupportingFileLen)
+		}
+		full := filepath.Join(b.Root, filepath.FromSlash(f.Path))
+		body, err := os.ReadFile(full) //nolint:gosec // path validated by LoadBundle
+		if err != nil {
+			return nil, fmt.Errorf("%w: read supporting %q: %v",
+				ErrBundleInvalid, f.Path, err)
+		}
+		supporting[f.Path] = body
+	}
+
+	return &SkillContents{
+		Name:        name,
+		Category:    category,
+		Description: description,
+		Content:     skillStr,
+		Supporting:  supporting,
+	}, nil
+}
+
+// frontmatterField returns the value of `key:` inside the leading
+// YAML frontmatter block (`---\n…\n---`). Returns "" when the block
+// is absent, the key isn't there, or the value is blank. Pure
+// string-scan to avoid pulling in a YAML lib for two fields.
+//
+// Limitations:
+//   - Single-line scalar values only. Multi-line / block scalars
+//     return the first line.
+//   - Trims surrounding whitespace + double-quotes.
+func frontmatterField(content, key string) string {
+	if !strings.HasPrefix(content, "---\n") && !strings.HasPrefix(content, "---\r\n") {
+		return ""
+	}
+	rest := strings.TrimPrefix(content, "---")
+	rest = strings.TrimPrefix(rest, "\r")
+	rest = strings.TrimPrefix(rest, "\n")
+	end := strings.Index(rest, "\n---")
+	if end < 0 {
+		return ""
+	}
+	block := rest[:end]
+	prefix := key + ":"
+	for _, line := range strings.Split(block, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, prefix) {
+			continue
+		}
+		v := strings.TrimSpace(strings.TrimPrefix(line, prefix))
+		v = strings.TrimSuffix(strings.TrimPrefix(v, `"`), `"`)
+		v = strings.TrimSuffix(strings.TrimPrefix(v, `'`), `'`)
+		return v
+	}
+	return ""
+}

--- a/internal/marketplace/skill_extract_test.go
+++ b/internal/marketplace/skill_extract_test.go
@@ -1,0 +1,277 @@
+package marketplace
+
+import (
+	"crypto/ed25519"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// Phase 13 WS#13.C — extraction tests. Build verified bundles via the
+// same makeBundle helper from bundle_test.go (the helper itself
+// signs + writes to a temp dir), then run ExtractSkill across them.
+
+const minimalFrontmatter = `---
+name: weather-tool
+description: Look up the weather at a given location
+category: utility
+---
+# Weather
+
+Use this skill to fetch the current weather.
+`
+
+func TestExtractSkill_HappyPath(t *testing.T) {
+	t.Parallel()
+	kp, _ := GenerateKeypair()
+	root := makeBundle(t, kp, []fixtureFile{
+		{Path: SkillFilename, Content: []byte(minimalFrontmatter)},
+		{Path: "examples/sample.txt", Content: []byte("sample input")},
+	}, nil)
+
+	b, err := LoadBundle(root, []ed25519.PublicKey{kp.Public})
+	if err != nil {
+		t.Fatalf("LoadBundle: %v", err)
+	}
+	got, err := ExtractSkill(b)
+	if err != nil {
+		t.Fatalf("ExtractSkill: %v", err)
+	}
+	if got.Name != "weather-tool" {
+		t.Errorf("Name = %q, want weather-tool", got.Name)
+	}
+	if got.Category != "utility" {
+		t.Errorf("Category = %q, want utility", got.Category)
+	}
+	if !strings.Contains(got.Description, "weather") {
+		t.Errorf("Description = %q, missing 'weather'", got.Description)
+	}
+	if got.Content != minimalFrontmatter {
+		t.Error("Content not preserved verbatim")
+	}
+	if len(got.Supporting) != 1 {
+		t.Errorf("supporting count = %d, want 1", len(got.Supporting))
+	}
+	if string(got.Supporting["examples/sample.txt"]) != "sample input" {
+		t.Errorf("supporting bytes wrong: %q", got.Supporting["examples/sample.txt"])
+	}
+}
+
+func TestExtractSkill_NoSkillMD(t *testing.T) {
+	t.Parallel()
+	kp, _ := GenerateKeypair()
+	root := makeBundle(t, kp, []fixtureFile{
+		{Path: "README.md", Content: []byte("# nope")},
+	}, nil)
+	b, _ := LoadBundle(root, []ed25519.PublicKey{kp.Public})
+
+	_, err := ExtractSkill(b)
+	if !errors.Is(err, ErrBundleInvalid) {
+		t.Errorf("err = %v, want ErrBundleInvalid", err)
+	}
+	if !strings.Contains(err.Error(), SkillFilename) {
+		t.Errorf("error should name SKILL.md: %v", err)
+	}
+}
+
+func TestExtractSkill_NilBundle(t *testing.T) {
+	t.Parallel()
+	_, err := ExtractSkill(nil)
+	if !errors.Is(err, ErrBundleInvalid) {
+		t.Errorf("err = %v, want ErrBundleInvalid", err)
+	}
+}
+
+func TestExtractSkill_MissingCategory(t *testing.T) {
+	t.Parallel()
+	kp, _ := GenerateKeypair()
+	body := `---
+name: x
+description: a description
+---
+content`
+	root := makeBundle(t, kp, []fixtureFile{
+		{Path: SkillFilename, Content: []byte(body)},
+	}, nil)
+	b, _ := LoadBundle(root, []ed25519.PublicKey{kp.Public})
+	_, err := ExtractSkill(b)
+	if !errors.Is(err, ErrBundleInvalid) {
+		t.Errorf("err = %v, want ErrBundleInvalid", err)
+	}
+	if !strings.Contains(err.Error(), "category") {
+		t.Errorf("error should mention category: %v", err)
+	}
+}
+
+func TestExtractSkill_FrontmatterFallsBackToManifest(t *testing.T) {
+	t.Parallel()
+	kp, _ := GenerateKeypair()
+	// SKILL.md without name/description in frontmatter — fall back to
+	// manifest fields. Category MUST be in frontmatter though.
+	body := `---
+category: utility
+---
+content`
+	root := makeBundle(t, kp, []fixtureFile{
+		{Path: SkillFilename, Content: []byte(body)},
+	}, func(m *Manifest) {
+		m.Name = "manifest-name"
+		m.Description = "from manifest"
+	})
+	b, _ := LoadBundle(root, []ed25519.PublicKey{kp.Public})
+	got, err := ExtractSkill(b)
+	if err != nil {
+		t.Fatalf("ExtractSkill: %v", err)
+	}
+	if got.Name != "manifest-name" {
+		t.Errorf("Name = %q, want manifest-name (frontmatter fallback)", got.Name)
+	}
+	if got.Description != "from manifest" {
+		t.Errorf("Description = %q, want from manifest", got.Description)
+	}
+}
+
+func TestExtractSkill_InvalidName(t *testing.T) {
+	t.Parallel()
+	kp, _ := GenerateKeypair()
+	body := `---
+name: "has spaces and !! chars"
+description: x
+category: utility
+---
+content`
+	root := makeBundle(t, kp, []fixtureFile{
+		{Path: SkillFilename, Content: []byte(body)},
+	}, nil)
+	b, _ := LoadBundle(root, []ed25519.PublicKey{kp.Public})
+	_, err := ExtractSkill(b)
+	if !errors.Is(err, ErrBundleInvalid) {
+		t.Errorf("err = %v, want ErrBundleInvalid", err)
+	}
+}
+
+func TestExtractSkill_DescriptionLengthBounds(t *testing.T) {
+	t.Parallel()
+	kp, _ := GenerateKeypair()
+	long := strings.Repeat("a", MaxSkillDescriptionLen+1)
+	body := `---
+name: x
+description: ` + long + `
+category: utility
+---
+content`
+	root := makeBundle(t, kp, []fixtureFile{
+		{Path: SkillFilename, Content: []byte(body)},
+	}, nil)
+	b, _ := LoadBundle(root, []ed25519.PublicKey{kp.Public})
+	_, err := ExtractSkill(b)
+	if !errors.Is(err, ErrBundleInvalid) {
+		t.Errorf("err = %v, want ErrBundleInvalid (long description)", err)
+	}
+}
+
+func TestExtractSkill_QuotedFrontmatterValues(t *testing.T) {
+	t.Parallel()
+	kp, _ := GenerateKeypair()
+	body := `---
+name: "valid-name"
+description: 'a quoted description'
+category: "tools"
+---
+content`
+	root := makeBundle(t, kp, []fixtureFile{
+		{Path: SkillFilename, Content: []byte(body)},
+	}, nil)
+	b, _ := LoadBundle(root, []ed25519.PublicKey{kp.Public})
+	got, err := ExtractSkill(b)
+	if err != nil {
+		t.Fatalf("ExtractSkill: %v", err)
+	}
+	if got.Name != "valid-name" {
+		t.Errorf("Name = %q, want valid-name (quote-stripped)", got.Name)
+	}
+	if got.Description != "a quoted description" {
+		t.Errorf("Description = %q", got.Description)
+	}
+	if got.Category != "tools" {
+		t.Errorf("Category = %q", got.Category)
+	}
+}
+
+func TestExtractSkill_NoFrontmatter(t *testing.T) {
+	t.Parallel()
+	kp, _ := GenerateKeypair()
+	body := `# Skill body without frontmatter
+
+This skill has no YAML header at all.
+`
+	root := makeBundle(t, kp, []fixtureFile{
+		{Path: SkillFilename, Content: []byte(body)},
+	}, func(m *Manifest) {
+		m.Name = "manifest-fallback"
+		m.Description = "from manifest"
+	})
+	b, _ := LoadBundle(root, []ed25519.PublicKey{kp.Public})
+	_, err := ExtractSkill(b)
+	// No frontmatter → category missing → ErrBundleInvalid.
+	if !errors.Is(err, ErrBundleInvalid) {
+		t.Errorf("err = %v, want ErrBundleInvalid (missing category)", err)
+	}
+}
+
+func TestExtractSkill_MultipleSupportingFiles(t *testing.T) {
+	t.Parallel()
+	kp, _ := GenerateKeypair()
+	root := makeBundle(t, kp, []fixtureFile{
+		{Path: SkillFilename, Content: []byte(minimalFrontmatter)},
+		{Path: "templates/a.txt", Content: []byte("aaa")},
+		{Path: "templates/b.txt", Content: []byte("bbb")},
+		{Path: "examples/c.txt", Content: []byte("ccc")},
+	}, nil)
+	b, _ := LoadBundle(root, []ed25519.PublicKey{kp.Public})
+	got, err := ExtractSkill(b)
+	if err != nil {
+		t.Fatalf("ExtractSkill: %v", err)
+	}
+	if len(got.Supporting) != 3 {
+		t.Errorf("supporting count = %d, want 3", len(got.Supporting))
+	}
+	for _, p := range []string{"templates/a.txt", "templates/b.txt", "examples/c.txt"} {
+		if _, ok := got.Supporting[p]; !ok {
+			t.Errorf("missing supporting %q", p)
+		}
+	}
+}
+
+func TestFrontmatterField_BasicAndEdgeCases(t *testing.T) {
+	t.Parallel()
+	const fm = `---
+name: test
+description: hello
+empty:
+  spaced:    value with spaces
+quoted: "wrapped"
+---
+body`
+	cases := map[string]string{
+		"name":        "test",
+		"description": "hello",
+		"empty":       "",
+		"quoted":      "wrapped",
+		"missing":     "",
+	}
+	for k, want := range cases {
+		if got := frontmatterField(fm, k); got != want {
+			t.Errorf("frontmatterField(%q) = %q, want %q", k, got, want)
+		}
+	}
+
+	// No frontmatter block at all.
+	if got := frontmatterField("no frontmatter here", "name"); got != "" {
+		t.Errorf("no-block: got %q, want empty", got)
+	}
+	// Open-ended frontmatter (no closing `---`).
+	if got := frontmatterField("---\nname: x\nbody\n", "name"); got != "" {
+		t.Errorf("unclosed frontmatter: got %q, want empty", got)
+	}
+}


### PR DESCRIPTION
## Summary

**Stacked on #49**, re-bases to \`main\` once that lands.

Builds on the bundle parser with the marketplace boundary that translates a verified \`Bundle\` into the shape the existing reviewer-agent queue understands: one SKILL.md (with frontmatter) plus zero or more supporting files.

## What's in the PR

### \`SkillContents\`

\`\`\`go
type SkillContents struct {
    Name        string
    Category    string
    Description string
    Content     string            // raw SKILL.md (frontmatter included)
    Supporting  map[string][]byte // bundle-relative path → bytes
}
\`\`\`

### \`ExtractSkill(b *Bundle)\`

1. Locate \`SKILL.md\` in the manifest (constant filename — no producer-renames).
2. Read SKILL.md, parse YAML frontmatter for name + category + description.
3. Validate name/category against the same regex \`skills\` uses (alphanumeric/underscore/hyphen, max 63 chars). Reject early so error messages stay close to the producer.
4. **Fallbacks:** description: frontmatter → manifest. Name: frontmatter → manifest. **Category MUST be in frontmatter** — no safe default; categorisation drives UI tree placement.
5. Read every other manifest-listed file as supporting.

\`frontmatterField\` is a pure string-scan parser (avoid pulling in a YAML lib for two fields). Strips surrounding single + double quotes; returns \"\" on missing key / no frontmatter / unclosed block.

Length caps mirror \`skills.MaxDescriptionLen\` / \`MaxSupportingBytes\` so a bundle that passes Extract is guaranteed to clear the reviewer's bounds check.

## Boundary discipline

Deliberately does **not** import \`internal/skills\` — the boundary is owned by a follow-up that will call \`skills.Manager.CreateProposal\` + stage supporting files. Keeping marketplace skill-package-free makes the slice independently testable and lets the same parser feed into a future \"preview manifest before install\" UI flow that doesn't touch the proposal queue.

## Test plan

11 new tests: happy path with supporting file, no SKILL.md → \`ErrBundleInvalid\`, nil bundle, missing category, frontmatter falls back to manifest, invalid name rejected, description length-bound, quoted frontmatter values (single + double), no frontmatter at all → category missing, multiple supporting files preserved, \`frontmatterField\` edge cases.

\`go test ./...\` — 572/572 pass. \`golangci-lint run ./internal/marketplace/\` — 0 issues.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)