### PR TITLE
feat(skills,skillinstall): WS#13.C bundle install pipeline

### DIFF
--- a/internal/skillinstall/install.go
+++ b/internal/skillinstall/install.go
@@ -1,0 +1,167 @@
+// Package skillinstall is the bridge between marketplace.LoadBundle
+// and skills.Manager — the WS#13.C install pipeline that takes a
+// signed bundle on disk, verifies it, and stages every file into
+// the existing reviewer-agent proposal queue.
+//
+// Why a separate package: marketplace stays skill-package-free
+// (so it can be reused from a future "preview manifest" UI flow
+// that doesn't touch the proposal queue), and skills stays
+// marketplace-free (so the package's surface remains the
+// curator/reviewer pipeline that predates marketplace). This
+// package is the single place that knows about both ends.
+package skillinstall
+
+import (
+	"crypto/ed25519"
+	"errors"
+	"fmt"
+
+	"github.com/euraika-labs/pan-agent/internal/marketplace"
+	"github.com/euraika-labs/pan-agent/internal/skills"
+)
+
+// ErrAlreadyExists is returned when a skill with the same
+// (category, name) already exists in the active tree. The marketplace
+// UI shows this distinct from generic install errors so it can offer
+// an "uninstall + reinstall" or "upgrade" flow rather than a generic
+// "install failed" message.
+var ErrAlreadyExists = errors.New("skillinstall: skill already exists")
+
+// Result reports what Install did. ProposalID is the uuid the
+// reviewer agent will see in /v1/skills/proposals; the desktop UI
+// surfaces a notification + link to the review queue.
+type Result struct {
+	ProposalID  string
+	SkillName   string
+	Category    string
+	Description string
+	// Publisher is the public-key hex of the signer. The desktop UI
+	// shows a fingerprint so the reviewer can compare against the
+	// expected publisher before approving.
+	Publisher string
+	// Supporting reports how many supporting files were staged
+	// alongside the SKILL.md.
+	Supporting int
+}
+
+// Install verifies the bundle at bundleRoot against trustedPubs,
+// extracts the skill, calls skills.Manager.CreateProposal to stage
+// SKILL.md, then stages every supporting file via WriteProposalFile.
+//
+// Failure modes (all wrapped sentinels — callers use errors.Is):
+//
+//	marketplace.ErrSignatureInvalid     — sig missing/malformed/tampered
+//	marketplace.ErrUntrustedPublisher   — sig valid, publisher not pinned
+//	marketplace.ErrBundleInvalid        — layout / hash / size violation
+//	skillinstall.ErrAlreadyExists       — collision with active skill
+//
+// On success the bundle is left in place — Install does NOT delete
+// or move it. Cleanup is the caller's responsibility (the desktop
+// downloads bundles to a temp dir + removes them after install).
+//
+// Pre-condition: mgr is bound to the profile that should receive the
+// proposal. trustedPubs follows marketplace.Verify's semantics — nil
+// is test-only.
+func Install(bundleRoot string, trustedPubs []ed25519.PublicKey, mgr *skills.Manager, sessionID string) (*Result, error) {
+	if mgr == nil {
+		return nil, fmt.Errorf("skillinstall: Install: nil manager")
+	}
+
+	// 1. Verify the bundle (sig + hashes + layout).
+	b, err := marketplace.LoadBundle(bundleRoot, trustedPubs)
+	if err != nil {
+		return nil, err // pass through wrapped sentinel
+	}
+
+	// 2. Extract the skill contents (frontmatter + supporting files).
+	contents, err := marketplace.ExtractSkill(b)
+	if err != nil {
+		return nil, err
+	}
+
+	// 3. Stage SKILL.md as a proposal. CreateProposal handles guard
+	//    scanning, name + category validation, and the active-tree
+	//    collision check.
+	source := "marketplace:" + marketplace.FingerprintOf(parsePublicKeyOrEmpty(b.Manifest.PublicKeyHex))
+	meta, _, err := mgr.CreateProposal(
+		contents.Name,
+		contents.Category,
+		contents.Description,
+		contents.Content,
+		sessionID,
+		source,
+	)
+	if err != nil {
+		// Translate the well-known "already exists" message from
+		// CreateProposal so the marketplace UI can offer the
+		// reinstall/upgrade flow.
+		if isAlreadyExistsErr(err) {
+			return nil, fmt.Errorf("%w: %v", ErrAlreadyExists, err)
+		}
+		return nil, fmt.Errorf("skillinstall: CreateProposal: %w", err)
+	}
+
+	// 4. Stage every supporting file into the same proposal dir.
+	staged := 0
+	for relPath, body := range contents.Supporting {
+		if err := mgr.WriteProposalFile(meta.ID, relPath, body); err != nil {
+			// Best-effort cleanup is the reviewer-agent's job — we
+			// don't unwind the proposal directory because partial
+			// state is still useful for diagnosing what failed.
+			return nil, fmt.Errorf("skillinstall: stage %q: %w", relPath, err)
+		}
+		staged++
+	}
+
+	return &Result{
+		ProposalID:  meta.ID,
+		SkillName:   contents.Name,
+		Category:    contents.Category,
+		Description: contents.Description,
+		Publisher:   b.Manifest.PublicKeyHex,
+		Supporting:  staged,
+	}, nil
+}
+
+// parsePublicKeyOrEmpty is a small helper for the source-tag string —
+// returns a 32-byte zero key on parse failure rather than propagating
+// the error, because the source field is best-effort metadata, not a
+// verification surface (Verify already ran in LoadBundle).
+func parsePublicKeyOrEmpty(hex string) ed25519.PublicKey {
+	pub, err := marketplace.ParsePublicKey(hex)
+	if err != nil {
+		return make(ed25519.PublicKey, marketplace.PublicKeySize)
+	}
+	return pub
+}
+
+// isAlreadyExistsErr scans the CreateProposal error chain for the
+// well-known "already exists" wording. We don't have a dedicated
+// sentinel in skills (yet — that's a follow-up), so string-matching
+// is the bridge for now. Documented so the day a sentinel lands,
+// this scan can be replaced with errors.Is.
+func isAlreadyExistsErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return containsAny(msg, []string{"already exists"})
+}
+
+func containsAny(s string, needles []string) bool {
+	for _, n := range needles {
+		if len(n) <= len(s) && stringContains(s, n) {
+			return true
+		}
+	}
+	return false
+}
+
+func stringContains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/skillinstall/install_test.go
+++ b/internal/skillinstall/install_test.go
@@ -1,0 +1,278 @@
+package skillinstall
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/euraika-labs/pan-agent/internal/marketplace"
+	"github.com/euraika-labs/pan-agent/internal/skills"
+)
+
+// Phase 13 WS#13.C — install pipeline tests. The marketplace +
+// skills primitives are covered in their own packages; these
+// tests pin the bridge contract: bundle in → proposal out, with
+// proper error mapping for the four failure modes the desktop UI
+// distinguishes (sig invalid / untrusted / bundle invalid /
+// already exists).
+
+const skillBody = `---
+name: weather-tool
+description: Look up the weather at a given location
+category: utility
+---
+# Weather
+
+Use this skill to fetch the current weather.
+`
+
+// makeSignedBundle writes a small bundle to a temp dir, signed by
+// kp. supportingFiles are staged alongside the SKILL.md; their
+// paths must match what the test expects to see in the resulting
+// proposal directory.
+func makeSignedBundle(t *testing.T, kp *marketplace.Keypair, supportingFiles map[string][]byte) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	// Write SKILL.md.
+	skillPath := filepath.Join(dir, marketplace.SkillFilename)
+	if err := os.WriteFile(skillPath, []byte(skillBody), 0o644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+
+	// Write supporting files.
+	for rel, body := range supportingFiles {
+		full := filepath.Join(dir, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(full, body, 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+
+	// Build manifest manually so we don't depend on the producer-
+	// side BuildManifest helper that may or may not be in this
+	// branch.
+	files := []marketplace.ManifestFile{
+		manifestFileFor(marketplace.SkillFilename, []byte(skillBody)),
+	}
+	for rel, body := range supportingFiles {
+		files = append(files, manifestFileFor(rel, body))
+	}
+	m := &marketplace.Manifest{
+		Schema: marketplace.SchemaSkillV1,
+		Name:   "weather-tool", Version: "1.0.0", Author: "alice",
+		Description: "test", SignedAt: 1700000000,
+		Files: files,
+	}
+	if err := marketplace.Sign(m, kp); err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	mb, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, marketplace.ManifestFilename), mb, 0o644,
+	); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	return dir
+}
+
+func manifestFileFor(path string, body []byte) marketplace.ManifestFile {
+	sum := sha256.Sum256(body)
+	return marketplace.ManifestFile{
+		Path: path, SHA256: hex.EncodeToString(sum[:]), Size: int64(len(body)),
+	}
+}
+
+// setupManager creates a Manager with PAN_AGENT_HOME isolated to a
+// temp dir — Install writes into the configured profile's skills
+// directory; we don't want to pollute the developer's real one.
+func setupManager(t *testing.T) *skills.Manager {
+	t.Helper()
+	t.Setenv("PAN_AGENT_HOME", t.TempDir())
+	return skills.NewManager("")
+}
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+func TestInstall_HappyPath(t *testing.T) {
+	kp, _ := marketplace.GenerateKeypair()
+	root := makeSignedBundle(t, kp, map[string][]byte{
+		"templates/example.txt": []byte("template body"),
+		"references/guide.md":   []byte("guide body"),
+	})
+	mgr := setupManager(t)
+
+	res, err := Install(root, []ed25519.PublicKey{kp.Public}, mgr, "session-1")
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if res.ProposalID == "" {
+		t.Error("ProposalID empty")
+	}
+	if res.SkillName != "weather-tool" {
+		t.Errorf("SkillName = %q, want weather-tool", res.SkillName)
+	}
+	if res.Category != "utility" {
+		t.Errorf("Category = %q, want utility", res.Category)
+	}
+	if res.Supporting != 2 {
+		t.Errorf("Supporting = %d, want 2", res.Supporting)
+	}
+	if !strings.HasPrefix(res.Publisher, kp.PublicKeyHex()[:16]) {
+		t.Errorf("Publisher prefix mismatch: %q", res.Publisher)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Error mapping
+// ---------------------------------------------------------------------------
+
+func TestInstall_NilManager(t *testing.T) {
+	kp, _ := marketplace.GenerateKeypair()
+	root := makeSignedBundle(t, kp, nil)
+	_, err := Install(root, []ed25519.PublicKey{kp.Public}, nil, "s")
+	if err == nil {
+		t.Error("expected nil-manager error")
+	}
+}
+
+func TestInstall_UntrustedPublisher(t *testing.T) {
+	signer, _ := marketplace.GenerateKeypair()
+	other, _ := marketplace.GenerateKeypair()
+	root := makeSignedBundle(t, signer, nil)
+	mgr := setupManager(t)
+
+	_, err := Install(root, []ed25519.PublicKey{other.Public}, mgr, "s")
+	if !errors.Is(err, marketplace.ErrUntrustedPublisher) {
+		t.Errorf("err = %v, want ErrUntrustedPublisher", err)
+	}
+}
+
+func TestInstall_TamperedBundle(t *testing.T) {
+	kp, _ := marketplace.GenerateKeypair()
+	root := makeSignedBundle(t, kp, nil)
+	// Tamper with SKILL.md after signing — hash mismatch.
+	if err := os.WriteFile(
+		filepath.Join(root, marketplace.SkillFilename),
+		[]byte("# tampered"), 0o644,
+	); err != nil {
+		t.Fatalf("tamper: %v", err)
+	}
+	mgr := setupManager(t)
+
+	_, err := Install(root, []ed25519.PublicKey{kp.Public}, mgr, "s")
+	if !errors.Is(err, marketplace.ErrBundleInvalid) {
+		t.Errorf("err = %v, want ErrBundleInvalid", err)
+	}
+}
+
+func TestInstall_AlreadyExists(t *testing.T) {
+	kp, _ := marketplace.GenerateKeypair()
+	root := makeSignedBundle(t, kp, nil)
+	mgr := setupManager(t)
+
+	// First install: succeeds.
+	res, err := Install(root, []ed25519.PublicKey{kp.Public}, mgr, "s")
+	if err != nil {
+		t.Fatalf("first Install: %v", err)
+	}
+
+	// Promote the proposal to active so a SECOND install hits the
+	// active-collision check.
+	// (Manually copy the SKILL.md to the active path. The skills
+	// reviewer would normally handle promotion; for this test we
+	// just mimic the resulting on-disk state.)
+	if err := promoteProposalToActive(t, mgr, res); err != nil {
+		t.Fatalf("promote: %v", err)
+	}
+
+	// Second install: should fail with ErrAlreadyExists.
+	_, err = Install(root, []ed25519.PublicKey{kp.Public}, mgr, "s")
+	if !errors.Is(err, ErrAlreadyExists) {
+		t.Errorf("err = %v, want ErrAlreadyExists", err)
+	}
+}
+
+// promoteProposalToActive simulates the reviewer agent promoting a
+// proposal so a second install of the same skill hits the active
+// collision check. It writes the skill into the active path.
+func promoteProposalToActive(t *testing.T, mgr *skills.Manager, res *Result) error {
+	t.Helper()
+	// The skills package doesn't expose the active-path resolver; the
+	// simplest cross-package mimic is to call EditActiveSkill — but
+	// that requires the active dir to already exist. So instead we
+	// use the public CreateProposal + a manual filesystem move. To
+	// keep the test independent of internal layout, we just do a
+	// filesystem-level mkdir of an active dir with a SKILL.md.
+	// Path: paths.SkillsDir() / <category> / <name> / SKILL.md.
+	home := os.Getenv("PAN_AGENT_HOME")
+	if home == "" {
+		t.Fatalf("PAN_AGENT_HOME not set")
+	}
+	activeDir := filepath.Join(home, "skills", res.Category, res.SkillName)
+	if err := os.MkdirAll(activeDir, 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(
+		filepath.Join(activeDir, "SKILL.md"),
+		[]byte(skillBody), 0o600,
+	)
+}
+
+func TestInstall_BundleNotFound(t *testing.T) {
+	mgr := setupManager(t)
+	_, err := Install("/nonexistent/path/x", nil, mgr, "s")
+	if !errors.Is(err, marketplace.ErrBundleInvalid) {
+		t.Errorf("err = %v, want ErrBundleInvalid", err)
+	}
+}
+
+func TestInstall_SupportingFileGuardBlocked(t *testing.T) {
+	kp, _ := marketplace.GenerateKeypair()
+	// Plant a supporting file with content that the skills.Guard
+	// will block (an AKIA-prefixed AWS key is a known guard pattern).
+	root := makeSignedBundle(t, kp, map[string][]byte{
+		"references/creds.txt": []byte("AKIAIOSFODNN7EXAMPLE"),
+	})
+	mgr := setupManager(t)
+
+	_, err := Install(root, []ed25519.PublicKey{kp.Public}, mgr, "s")
+	if err == nil {
+		t.Error("expected guard-block error")
+	}
+	if !strings.Contains(err.Error(), "creds.txt") {
+		t.Errorf("error should name the file: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func TestStringContains(t *testing.T) {
+	if !stringContains("the quick brown fox", "quick") {
+		t.Error("stringContains positive case")
+	}
+	if stringContains("hello", "world") {
+		t.Error("stringContains negative case")
+	}
+	if !stringContains("foo", "foo") {
+		t.Error("stringContains exact match")
+	}
+	if stringContains("", "x") {
+		t.Error("stringContains empty haystack")
+	}
+}

--- a/internal/skills/manager.go
+++ b/internal/skills/manager.go
@@ -195,6 +195,49 @@ func (m *Manager) WriteSupportingFile(category, name, relPath string, content []
 	return atomicWrite(target, content, 0o600)
 }
 
+// WriteProposalFile writes a supporting file directly into a queued
+// proposal directory. Mirrors WriteSupportingFile (which targets the
+// active skill tree) — the marketplace install pipeline uses this
+// to stage every non-SKILL.md file from a verified bundle alongside
+// the SKILL.md that CreateProposal already wrote.
+//
+// proposalID must reference an existing proposal (the install
+// pipeline calls CreateProposal first to create the dir + SKILL.md).
+// relPath is the bundle-relative file path; same containment +
+// guard-scan + size-cap rules as WriteSupportingFile so a malicious
+// supporting file can't escape via path tricks or sneak unsigned
+// content past the reviewer guard.
+func (m *Manager) WriteProposalFile(proposalID, relPath string, content []byte) error {
+	if len(content) > MaxSupportingBytes {
+		return fmt.Errorf("file exceeds %d bytes", MaxSupportingBytes)
+	}
+	if err := validateRelativePath(relPath); err != nil {
+		return err
+	}
+	proposalDir, err := resolveProposalDir(m.Profile, proposalID)
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(proposalDir); err != nil {
+		return fmt.Errorf("proposal %s not found", proposalID)
+	}
+	target := filepath.Join(proposalDir, relPath)
+	// Defence-in-depth: confirm the resolved target stays inside the
+	// proposal dir even after path-segment normalisation.
+	rel, err := filepath.Rel(proposalDir, target)
+	if err != nil || rel == "." || strings.HasPrefix(rel, "..") ||
+		strings.HasPrefix(rel, string(filepath.Separator)) {
+		return fmt.Errorf("path escapes proposal directory")
+	}
+	if m.Guard != nil {
+		if scan := m.Guard.Scan(string(content)); scan.Blocked {
+			return fmt.Errorf("guard blocked supporting file %s: %d finding(s)",
+				relPath, len(scan.Findings))
+		}
+	}
+	return atomicWrite(target, content, 0o600)
+}
+
 // RemoveSupportingFile removes a supporting file from an active skill.
 func (m *Manager) RemoveSupportingFile(category, name, relPath string) error {
 	if err := validateRelativePath(relPath); err != nil {

--- a/internal/skills/write_proposal_file_test.go
+++ b/internal/skills/write_proposal_file_test.go
@@ -1,0 +1,122 @@
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Phase 13 WS#13.C — direct tests of WriteProposalFile, the helper
+// the marketplace install pipeline calls to stage supporting files
+// inside a proposal directory. The integration is covered in
+// internal/skillinstall; these tests pin the per-call validation.
+
+func TestWriteProposalFile_HappyPath(t *testing.T) {
+	withIsolatedAgentHome(t)
+	mgr := NewManager("default")
+
+	meta, _, err := mgr.CreateProposal(
+		"sup-test", "utility", "test description",
+		EnsureFrontmatter("body content", "sup-test", "test description"),
+		"sess", "marketplace:test",
+	)
+	if err != nil {
+		t.Fatalf("CreateProposal: %v", err)
+	}
+
+	body := []byte("template body")
+	if err := mgr.WriteProposalFile(meta.ID, "templates/x.txt", body); err != nil {
+		t.Fatalf("WriteProposalFile: %v", err)
+	}
+
+	// Confirm file landed in the proposal dir.
+	dir, err := resolveProposalDir(mgr.Profile, meta.ID)
+	if err != nil {
+		t.Fatalf("resolveProposalDir: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "templates", "x.txt"))
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != "template body" {
+		t.Errorf("body mismatch: %q", got)
+	}
+}
+
+func TestWriteProposalFile_RejectedPaths(t *testing.T) {
+	withIsolatedAgentHome(t)
+	mgr := NewManager("default")
+	meta, _, err := mgr.CreateProposal(
+		"sup-test2", "utility", "test description",
+		EnsureFrontmatter("body", "sup-test2", "test description"),
+		"sess", "marketplace:test",
+	)
+	if err != nil {
+		t.Fatalf("CreateProposal: %v", err)
+	}
+
+	cases := []string{
+		"",               // empty
+		"../escape.txt",  // traversal
+		"/abs/path.txt",  // abs
+		"SKILL.md",       // reserved
+		"_metadata.json", // reserved
+		"docs/x.txt",     // not a permitted top-level
+	}
+	for _, p := range cases {
+		err := mgr.WriteProposalFile(meta.ID, p, []byte("x"))
+		if err == nil {
+			t.Errorf("path %q: expected rejection", p)
+		}
+	}
+}
+
+func TestWriteProposalFile_NonexistentProposal(t *testing.T) {
+	withIsolatedAgentHome(t)
+	mgr := NewManager("default")
+	err := mgr.WriteProposalFile(
+		"00000000-0000-0000-0000-000000000000",
+		"templates/x.txt", []byte("x"))
+	if err == nil {
+		t.Error("expected proposal-not-found error")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error should mention 'not found': %v", err)
+	}
+}
+
+func TestWriteProposalFile_OversizedRejected(t *testing.T) {
+	withIsolatedAgentHome(t)
+	mgr := NewManager("default")
+	meta, _, _ := mgr.CreateProposal(
+		"sup-big", "utility", "x",
+		EnsureFrontmatter("body", "sup-big", "x"),
+		"sess", "marketplace:test",
+	)
+
+	body := make([]byte, MaxSupportingBytes+1)
+	err := mgr.WriteProposalFile(meta.ID, "templates/big.txt", body)
+	if err == nil {
+		t.Error("oversized: expected error")
+	}
+}
+
+func TestWriteProposalFile_GuardBlocked(t *testing.T) {
+	withIsolatedAgentHome(t)
+	mgr := NewManager("default")
+	meta, _, _ := mgr.CreateProposal(
+		"sup-guard", "utility", "x",
+		EnsureFrontmatter("body", "sup-guard", "x"),
+		"sess", "marketplace:test",
+	)
+
+	// AKIA-prefixed string is a known guard pattern.
+	err := mgr.WriteProposalFile(meta.ID, "templates/leak.txt", []byte("AKIAIOSFODNN7EXAMPLE"))
+	if err == nil {
+		t.Error("guard: expected block")
+	}
+	if !strings.Contains(err.Error(), "guard") {
+		t.Errorf("error should mention guard: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Bridges \`marketplace.LoadBundle\` (#49) and \`skills.Manager\` — the WS#13.C install pipeline that takes a signed bundle on disk, verifies it, and stages every file into the existing reviewer-agent proposal queue.

Builds on the marketplace stack (#48 #49 #50). The desktop UI's marketplace flow will call \`Install\` over an HTTP endpoint (next slice).

## What's in the PR

### \`internal/skills/manager.go\` — new method

\`WriteProposalFile(proposalID, relPath, content)\` — mirrors \`WriteSupportingFile\` (which targets the active tree) but writes into a queued proposal directory. Same containment + guard-scan + size-cap rules so a malicious supporting file can't escape via path tricks or sneak unsigned content past the reviewer guard.

### \`internal/skillinstall\` (new package)

\`Install(bundleRoot, trustedPubs, mgr, sessionID)\` is the bridge:

1. \`marketplace.LoadBundle\` — sig + hashes + layout.
2. \`marketplace.ExtractSkill\` — frontmatter, supporting files.
3. \`mgr.CreateProposal\` — stage SKILL.md.
4. \`mgr.WriteProposalFile\` per supporting file.

Four pass-through error sentinels for the desktop UI's branching:

| Error | Triggers |
|---|---|
| \`marketplace.ErrSignatureInvalid\` | sig missing/malformed/tampered |
| \`marketplace.ErrUntrustedPublisher\` | sig valid, publisher not pinned |
| \`marketplace.ErrBundleInvalid\` | layout / hash / size violation |
| \`skillinstall.ErrAlreadyExists\` | collision with active skill |

Separate package keeps \`marketplace\` skill-package-free and \`skills\` marketplace-free; \`skillinstall\` is the single bridge that knows about both.

## Test plan

- **\`internal/skillinstall\`** (8 tests): happy path with 2 supporting files, nil manager, untrusted publisher, tampered SKILL.md, already-exists (after promoting proposal to active to trigger the collision), bundle-not-found, guard-blocked supporting file, stringContains helper sanity.
- **\`internal/skills\`** (5 tests): \`WriteProposalFile\` happy path, rejected paths (empty / traversal / absolute / reserved SKILL.md / reserved \`_metadata\` / not-a-permitted-top-level), nonexistent proposal, oversized rejected, guard blocked.
- \`go test ./...\` — 620/620 pass
- \`golangci-lint run ./internal/skills/ ./internal/skillinstall/\` — 0 issues

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)