### PR TITLE
feat(gateway): WS#13.B server-lifecycle wiring for the RAG watcher

### DIFF
--- a/internal/gateway/rag_lifecycle.go
+++ b/internal/gateway/rag_lifecycle.go
@@ -30,11 +30,13 @@ import (
 // continues to work without semantic-recall context.
 
 // Env var names — declared as constants so tests can reference the
-// same symbols + a future config-file backend can substitute.
+// same symbols + a future config-file backend can substitute. The
+// nosec annotations cover gosec G101 (hardcoded credentials): these
+// are the NAMES of env vars users set, not the values.
 const (
 	envRAGEmbedderURL     = "PAN_AGENT_RAG_EMBEDDER_URL"
 	envRAGEmbedderModel   = "PAN_AGENT_RAG_EMBEDDER_MODEL"
-	envRAGEmbedderAPIKey  = "PAN_AGENT_RAG_EMBEDDER_API_KEY"
+	envRAGEmbedderAPIKey  = "PAN_AGENT_RAG_EMBEDDER_API_KEY" // #nosec G101 -- env var name, not a credential value
 	envRAGEmbedderDim     = "PAN_AGENT_RAG_EMBEDDER_DIM"
 	envRAGWatcherInterval = "PAN_AGENT_RAG_WATCHER_INTERVAL"
 )

--- a/internal/gateway/rag_lifecycle.go
+++ b/internal/gateway/rag_lifecycle.go
@@ -1,0 +1,141 @@
+package gateway
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/euraika-labs/pan-agent/internal/rag"
+)
+
+// Phase 13 WS#13.B — server-lifecycle wiring for the RAG watcher.
+//
+// The pieces shipped in earlier slices:
+//
+//   #42 codec + storage helpers
+//   #43 embedder client
+//   #44 Index wrapper
+//   #45 HTTP endpoints (with lazy AttachRAGIndex)
+//   #46 polling watcher
+//   #47 chat-loop retrieval (env-gated)
+//
+// This slice connects them at startup. When the operator sets the
+// PAN_AGENT_RAG_EMBEDDER_URL + PAN_AGENT_RAG_EMBEDDER_MODEL env vars,
+// the gateway constructs an HTTPEmbedder, an Index over the existing
+// *storage.DB, and a Watcher; then attaches the index + starts the
+// watcher. Without those env vars the wiring is a no-op and chat
+// continues to work without semantic-recall context.
+
+// Env var names — declared as constants so tests can reference the
+// same symbols + a future config-file backend can substitute.
+const (
+	envRAGEmbedderURL     = "PAN_AGENT_RAG_EMBEDDER_URL"
+	envRAGEmbedderModel   = "PAN_AGENT_RAG_EMBEDDER_MODEL"
+	envRAGEmbedderAPIKey  = "PAN_AGENT_RAG_EMBEDDER_API_KEY"
+	envRAGEmbedderDim     = "PAN_AGENT_RAG_EMBEDDER_DIM"
+	envRAGWatcherInterval = "PAN_AGENT_RAG_WATCHER_INTERVAL"
+)
+
+// ConfigureRAGFromEnv reads the RAG-related env vars + builds the
+// embedder, index, and watcher. Called from Server.Start so the
+// wiring happens automatically when the operator configures the
+// embedder. Three documented outcomes:
+//
+//   - Both URL + Model unset → no-op, returns nil. Logs nothing
+//     (the operator opted out by not setting the env vars).
+//   - Embedder/Index/Watcher construction fails → returns the
+//     error wrapped. Caller decides whether to surface (Start
+//     logs to stderr; tests assert via the return value).
+//   - Success → index attached + watcher running. The first poll
+//     tick fires immediately so the indexer catches up to the
+//     existing message log on a fresh start.
+//
+// Idempotent: calling twice on the same server replaces the
+// previous index + restarts the watcher with the new config.
+func (s *Server) ConfigureRAGFromEnv(ctx context.Context) error {
+	url := strings.TrimSpace(os.Getenv(envRAGEmbedderURL))
+	model := strings.TrimSpace(os.Getenv(envRAGEmbedderModel))
+	if url == "" && model == "" {
+		// Operator opted out. Not an error.
+		return nil
+	}
+	if url == "" || model == "" {
+		return fmt.Errorf(
+			"both %s and %s must be set (or both unset to disable RAG)",
+			envRAGEmbedderURL, envRAGEmbedderModel)
+	}
+
+	cfg := rag.HTTPEmbedderConfig{
+		BaseURL: url,
+		APIKey:  strings.TrimSpace(os.Getenv(envRAGEmbedderAPIKey)),
+		Model:   model,
+	}
+	if dimStr := strings.TrimSpace(os.Getenv(envRAGEmbedderDim)); dimStr != "" {
+		dim, err := strconv.Atoi(dimStr)
+		if err != nil || dim < 0 {
+			return fmt.Errorf("%s must be a non-negative integer, got %q",
+				envRAGEmbedderDim, dimStr)
+		}
+		cfg.Dim = dim
+	}
+
+	em, err := rag.NewHTTPEmbedder(cfg)
+	if err != nil {
+		return fmt.Errorf("build embedder: %w", err)
+	}
+	idx, err := rag.NewIndex(em, s.db)
+	if err != nil {
+		return fmt.Errorf("build index: %w", err)
+	}
+	s.AttachRAGIndex(idx)
+
+	// Watcher. Stop any previously-running watcher first so a
+	// re-call replaces cleanly.
+	s.StopRAGWatcher()
+
+	opts := rag.WatcherOptions{}
+	if iv := strings.TrimSpace(os.Getenv(envRAGWatcherInterval)); iv != "" {
+		dur, err := time.ParseDuration(iv)
+		if err != nil {
+			return fmt.Errorf("%s: %w", envRAGWatcherInterval, err)
+		}
+		opts.Interval = dur
+	}
+
+	w, err := rag.NewWatcher(idx, s.db, opts)
+	if err != nil {
+		return fmt.Errorf("build watcher: %w", err)
+	}
+	if err := w.Start(ctx); err != nil {
+		return fmt.Errorf("start watcher: %w", err)
+	}
+	s.ragMu.Lock()
+	s.ragWatcher = w
+	s.ragMu.Unlock()
+	return nil
+}
+
+// StopRAGWatcher halts the watcher goroutine if one is running.
+// Idempotent: safe to call multiple times or when no watcher was
+// ever attached. Called from Server.Stop.
+func (s *Server) StopRAGWatcher() {
+	s.ragMu.Lock()
+	w := s.ragWatcher
+	s.ragWatcher = nil
+	s.ragMu.Unlock()
+	if w != nil {
+		_ = w.Stop()
+	}
+}
+
+// ragWatcherRunning reports whether a watcher is currently attached
+// + running. Exposed for tests + a future status endpoint.
+func (s *Server) ragWatcherRunning() bool {
+	s.ragMu.RLock()
+	w := s.ragWatcher
+	s.ragMu.RUnlock()
+	return w != nil && w.Running()
+}

--- a/internal/gateway/rag_lifecycle_test.go
+++ b/internal/gateway/rag_lifecycle_test.go
@@ -1,0 +1,239 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/euraika-labs/pan-agent/internal/rag"
+)
+
+// Phase 13 WS#13.B — server-lifecycle wiring tests for the RAG
+// watcher. The watcher itself is covered in internal/rag's suite;
+// these tests verify the env-driven boot path: env vars in →
+// embedder + index + watcher constructed → watcher running →
+// Stop halts cleanly.
+
+// fakeEmbeddingsServer returns an httptest server that responds to
+// /embeddings with one zero-vector per input. Lets the wiring test
+// run end-to-end without a real embedder provider.
+func fakeEmbeddingsServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Model string   `json:"model"`
+			Input []string `json:"input"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		var out struct {
+			Data []struct {
+				Embedding []float32 `json:"embedding"`
+				Index     int       `json:"index"`
+			} `json:"data"`
+			Model string `json:"model"`
+		}
+		out.Model = req.Model
+		for i := range req.Input {
+			out.Data = append(out.Data, struct {
+				Embedding []float32 `json:"embedding"`
+				Index     int       `json:"index"`
+			}{Embedding: make([]float32, 4), Index: i})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(out)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// ---------------------------------------------------------------------------
+// ConfigureRAGFromEnv
+// ---------------------------------------------------------------------------
+
+func TestConfigureRAGFromEnv_NoEnv_NoOp(t *testing.T) {
+	srv := setupTestServer(t)
+	t.Setenv(envRAGEmbedderURL, "")
+	t.Setenv(envRAGEmbedderModel, "")
+
+	if err := srv.ConfigureRAGFromEnv(context.Background()); err != nil {
+		t.Errorf("expected nil for unset env, got %v", err)
+	}
+	if srv.getRAGIndex() != nil {
+		t.Error("expected no index attached")
+	}
+	if srv.ragWatcherRunning() {
+		t.Error("expected watcher not running")
+	}
+}
+
+func TestConfigureRAGFromEnv_PartialEnvErrors(t *testing.T) {
+	srv := setupTestServer(t)
+
+	// URL only.
+	t.Setenv(envRAGEmbedderURL, "http://x")
+	t.Setenv(envRAGEmbedderModel, "")
+	if err := srv.ConfigureRAGFromEnv(context.Background()); err == nil {
+		t.Error("expected error when only URL is set")
+	}
+
+	// Model only.
+	t.Setenv(envRAGEmbedderURL, "")
+	t.Setenv(envRAGEmbedderModel, "model-x")
+	if err := srv.ConfigureRAGFromEnv(context.Background()); err == nil {
+		t.Error("expected error when only Model is set")
+	}
+}
+
+func TestConfigureRAGFromEnv_HappyPath(t *testing.T) {
+	srv := setupTestServer(t)
+	emb := fakeEmbeddingsServer(t)
+
+	t.Setenv(envRAGEmbedderURL, emb.URL)
+	t.Setenv(envRAGEmbedderModel, "test-model")
+	t.Setenv(envRAGEmbedderDim, "4")
+	t.Setenv(envRAGWatcherInterval, "100ms")
+
+	if err := srv.ConfigureRAGFromEnv(context.Background()); err != nil {
+		t.Fatalf("ConfigureRAGFromEnv: %v", err)
+	}
+	if srv.getRAGIndex() == nil {
+		t.Error("expected index attached")
+	}
+	if !srv.ragWatcherRunning() {
+		t.Error("expected watcher running")
+	}
+
+	// StopRAGWatcher should bring it down cleanly.
+	srv.StopRAGWatcher()
+	if srv.ragWatcherRunning() {
+		t.Error("expected watcher stopped after StopRAGWatcher")
+	}
+}
+
+func TestConfigureRAGFromEnv_BadDim(t *testing.T) {
+	srv := setupTestServer(t)
+	emb := fakeEmbeddingsServer(t)
+
+	t.Setenv(envRAGEmbedderURL, emb.URL)
+	t.Setenv(envRAGEmbedderModel, "test-model")
+	t.Setenv(envRAGEmbedderDim, "not-a-number")
+
+	if err := srv.ConfigureRAGFromEnv(context.Background()); err == nil {
+		t.Error("expected error on bad dim")
+	}
+}
+
+func TestConfigureRAGFromEnv_NegativeDim(t *testing.T) {
+	srv := setupTestServer(t)
+	emb := fakeEmbeddingsServer(t)
+
+	t.Setenv(envRAGEmbedderURL, emb.URL)
+	t.Setenv(envRAGEmbedderModel, "test-model")
+	t.Setenv(envRAGEmbedderDim, "-5")
+
+	if err := srv.ConfigureRAGFromEnv(context.Background()); err == nil {
+		t.Error("expected error on negative dim")
+	}
+}
+
+func TestConfigureRAGFromEnv_BadInterval(t *testing.T) {
+	srv := setupTestServer(t)
+	emb := fakeEmbeddingsServer(t)
+
+	t.Setenv(envRAGEmbedderURL, emb.URL)
+	t.Setenv(envRAGEmbedderModel, "test-model")
+	t.Setenv(envRAGWatcherInterval, "bogus")
+
+	if err := srv.ConfigureRAGFromEnv(context.Background()); err == nil {
+		t.Error("expected error on bad interval")
+	}
+}
+
+func TestConfigureRAGFromEnv_Idempotent(t *testing.T) {
+	srv := setupTestServer(t)
+	emb := fakeEmbeddingsServer(t)
+
+	t.Setenv(envRAGEmbedderURL, emb.URL)
+	t.Setenv(envRAGEmbedderModel, "test-model")
+	t.Setenv(envRAGEmbedderDim, "4")
+	t.Setenv(envRAGWatcherInterval, "100ms")
+
+	if err := srv.ConfigureRAGFromEnv(context.Background()); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	first := srv.getRAGIndex()
+
+	if err := srv.ConfigureRAGFromEnv(context.Background()); err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	second := srv.getRAGIndex()
+
+	// Second call replaces the index (different pointer).
+	if first == second {
+		t.Error("expected re-call to construct a new index")
+	}
+	if !srv.ragWatcherRunning() {
+		t.Error("expected watcher still running after re-config")
+	}
+	srv.StopRAGWatcher()
+}
+
+// ---------------------------------------------------------------------------
+// StopRAGWatcher safety
+// ---------------------------------------------------------------------------
+
+func TestStopRAGWatcher_NoOpWhenUnattached(t *testing.T) {
+	srv := setupTestServer(t)
+	srv.StopRAGWatcher() // should not panic
+	if srv.ragWatcherRunning() {
+		t.Error("ragWatcherRunning true on fresh server")
+	}
+}
+
+func TestStopRAGWatcher_Idempotent(t *testing.T) {
+	srv := setupTestServer(t)
+	emb := fakeEmbeddingsServer(t)
+
+	t.Setenv(envRAGEmbedderURL, emb.URL)
+	t.Setenv(envRAGEmbedderModel, "test-model")
+	t.Setenv(envRAGEmbedderDim, "4")
+
+	if err := srv.ConfigureRAGFromEnv(context.Background()); err != nil {
+		t.Fatalf("configure: %v", err)
+	}
+	srv.StopRAGWatcher()
+	srv.StopRAGWatcher() // second call should not panic
+	if srv.ragWatcherRunning() {
+		t.Error("watcher still running after double Stop")
+	}
+}
+
+// Sanity: imports via env constants must match the documented names so
+// a config-file backend (future) can read them by string lookup.
+func TestEnvVarNamesPinned(t *testing.T) {
+	cases := map[string]string{
+		envRAGEmbedderURL:     "PAN_AGENT_RAG_EMBEDDER_URL",
+		envRAGEmbedderModel:   "PAN_AGENT_RAG_EMBEDDER_MODEL",
+		envRAGEmbedderAPIKey:  "PAN_AGENT_RAG_EMBEDDER_API_KEY",
+		envRAGEmbedderDim:     "PAN_AGENT_RAG_EMBEDDER_DIM",
+		envRAGWatcherInterval: "PAN_AGENT_RAG_WATCHER_INTERVAL",
+	}
+	for got, want := range cases {
+		if got != want {
+			t.Errorf("env name = %q, want %q", got, want)
+		}
+	}
+}
+
+// Sanity: rag package types are still in the expected shape (catches
+// silent breakage from upstream rag refactors).
+func TestRAGTypeShapeUnchanged(t *testing.T) {
+	var _ rag.HTTPEmbedderConfig
+	var _ rag.WatcherOptions
+	if !strings.Contains(envRAGEmbedderURL, "RAG") {
+		t.Error("env constants drifted")
+	}
+}

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -55,11 +55,15 @@ type Server struct {
 	recoveryOnce sync.Once
 	recoveryH    *recovery.Handler
 
-	// ragMu guards ragIndex. Phase 13 WS#13.B — the index is wired in
-	// after construction (so the desktop UI can hot-swap embedders);
-	// nil means "not configured" and handlers respond 503.
-	ragMu    sync.RWMutex
-	ragIndex *rag.Index
+	// ragMu guards ragIndex + ragWatcher. Phase 13 WS#13.B — the
+	// index is wired in after construction (so the desktop UI can
+	// hot-swap embedders); nil means "not configured" and handlers
+	// respond 503. The watcher runs as a goroutine, so its lifetime
+	// is server-bound: StartRAGWatcher arms it (called from Start),
+	// StopRAGWatcher halts it (called from Stop).
+	ragMu      sync.RWMutex
+	ragIndex   *rag.Index
+	ragWatcher *rag.Watcher
 }
 
 // getLLMClient returns the current LLM client under a read lock.
@@ -127,6 +131,16 @@ func (s *Server) Start() error {
 	if err := writePidFile(); err != nil {
 		fmt.Fprintf(os.Stderr, "pan-agent: warning: PID file write failed: %v\n", err)
 	}
+
+	// Phase 13 WS#13.B — best-effort RAG watcher startup. Reads env
+	// vars (see ConfigureRAGFromEnv); if unconfigured this is a no-op
+	// and chat continues to work without semantic-recall context.
+	// Failure to start the watcher logs but does NOT block the
+	// listener — RAG is augmentative, not required.
+	if err := s.ConfigureRAGFromEnv(context.Background()); err != nil {
+		fmt.Fprintf(os.Stderr, "pan-agent: warning: RAG watcher disabled: %v\n", err)
+	}
+
 	fmt.Printf("pan-agent API listening on http://%s\n", s.Addr)
 	return s.httpServer.Serve(ln)
 }
@@ -144,6 +158,9 @@ func writePidFile() error {
 // Stop gracefully shuts down the server. It waits for in-flight requests to
 // finish or until ctx is cancelled, whichever comes first.
 func (s *Server) Stop(ctx context.Context) error {
+	// Halt the RAG watcher first so it doesn't try to write to a
+	// closing DB. Idempotent + safe when no watcher was attached.
+	s.StopRAGWatcher()
 	return s.httpServer.Shutdown(ctx)
 }
 


### PR DESCRIPTION
## Summary

Connects the WS#13.B substrate at startup. With the embedder env vars set, the gateway constructs an \`HTTPEmbedder\`, an \`Index\` over the existing \`*storage.DB\`, and a \`Watcher\`; then attaches the index + starts the watcher goroutine.

**Default off** — without the env vars the wiring is a no-op and chat continues to work without semantic-recall context.

## Env vars

| Var | Required | Default | Purpose |
|---|---|---|---|
| \`PAN_AGENT_RAG_EMBEDDER_URL\` | yes | — | OpenAI-compatible /embeddings endpoint |
| \`PAN_AGENT_RAG_EMBEDDER_MODEL\` | yes | — | Embedding model id |
| \`PAN_AGENT_RAG_EMBEDDER_API_KEY\` | no | empty | Bearer token (omit for local providers) |
| \`PAN_AGENT_RAG_EMBEDDER_DIM\` | no | 0 | Strict dim validation (0 = skip) |
| \`PAN_AGENT_RAG_WATCHER_INTERVAL\` | no | 5s | Watcher poll interval |

## What's in the PR

### \`internal/gateway/server.go\`

- New \`ragWatcher\` field alongside the existing \`ragIndex\` from #45. Both guarded by \`ragMu\`.
- \`Server.Start\` calls \`ConfigureRAGFromEnv\` after PID-file write but before \`httpServer.Serve\`. Failure logs to stderr but does **not** block the listener — RAG is augmentative.
- \`Server.Stop\` calls \`StopRAGWatcher\` before \`httpServer.Shutdown\` so the watcher doesn't try to write to a closing DB.

### \`internal/gateway/rag_lifecycle.go\` (new)

- \`ConfigureRAGFromEnv(ctx)\` — three outcomes: **no-op** (both URL + Model unset), **error** (anything else fails), **success** (index attached + watcher running). Idempotent.
- \`StopRAGWatcher\` — halts the goroutine. Idempotent + safe when no watcher was ever attached.
- \`ragWatcherRunning\` — current state (exposed for tests + a future status endpoint).

## Test plan

11 new tests:
- No-op when env unset
- Partial env (URL only / Model only) rejected
- **Happy path**: env in → embedder built → index attached → watcher running → \`StopRAGWatcher\` halts cleanly
- Bad dim (non-numeric / negative) rejected
- Bad watcher interval rejected
- Idempotent re-config: second call replaces the index
- \`StopRAGWatcher\` no-op when unattached + idempotent
- Env var names pinned to documented strings (catches silent rename drift)
- rag package type shapes unchanged

\`go test ./...\` — 694/694 pass. \`golangci-lint run ./internal/gateway/\` — 0 issues.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)