### PR TITLE
feat(skills): WS#13.E cookbook — clipboard-summarise + stripe-recent-charges

### DIFF
--- a/internal/skills/embed/cookbook/clipboard-summarise.md
+++ b/internal/skills/embed/cookbook/clipboard-summarise.md
@@ -1,0 +1,73 @@
+---
+name: clipboard-summarise
+description: "Read the system clipboard and produce a short summary the user can paste back."
+---
+
+## When to use
+
+- The user says "summarise this" / "tl;dr" / "what's on my clipboard"
+  AND has already copied content (URL, article, message thread, etc.)
+  outside the agent.
+- The user pastes a long block into chat — already in the
+  conversation, no clipboard read needed; skip this skill.
+- Cross-platform: macOS, Linux, Windows. The clipboard tool handles
+  the platform split.
+
+## Steps
+
+1. Read the clipboard:
+
+       clipboard intent: "read"
+
+   Returns one of:
+     - text content (URLs, plain text, markdown, code snippets)
+     - "<empty>" → tell the user nothing is on the clipboard and
+       stop. Do NOT fabricate a summary.
+
+2. Detect the content shape from the first non-blank line:
+     - `http://` or `https://` prefix → URL. Skip ahead to step 3.
+     - `<html` / `<!DOCTYPE` → HTML page. Skip ahead to step 3.
+     - looks like code (curly braces, `def `, `func `, `import`,
+       `#include`, etc.) → describe what the code does + flag
+       anything obviously broken. Stop after this step.
+     - else → treat as prose; produce a 3-bullet summary.
+
+3. **URL or HTML clipboard:** ask the user before fetching. The
+   clipboard contents may be private. Phrase the confirmation as:
+   "I see a link to <host>. Should I fetch it and summarise?"
+   On approval, call `browser intent: "open"` with the URL +
+   `browser intent: "get-text"` to read the rendered DOM. Continue
+   with step 4.
+
+4. Summarise to **at most 5 bullets**:
+   - One sentence per bullet.
+   - Lead with the most-actionable point.
+   - End with any explicit ask the source contains (e.g. "needs
+     review by Friday" → surface as bullet 5).
+   - Skip the bullet count when the source is shorter than ~4
+     paragraphs; a 1–2 line response reads better than a forced
+     list.
+
+5. Offer a follow-up:
+   - For a URL: "Want me to save this to your reading list?" (only
+     if a reading-list skill / saved-pages tool is installed).
+   - For prose / a message thread: "Draft a reply?" → switches to
+     a separate response-drafting skill.
+   - Otherwise: end the turn.
+
+## Anti-patterns
+
+- Don't paraphrase a URL without fetching it. The clipboard
+  carries only the URL; without a fetch you're inventing content.
+- Don't summarise a passphrase or 32+ char hex blob — those are
+  almost certainly secrets the user copied for paste, not for
+  summarisation. Decline politely + suggest they use a password
+  manager.
+
+## Failure modes
+
+- Clipboard tool unavailable on this platform → say so, suggest
+  the user paste the content into chat directly.
+- HTML parser returns gibberish (paywall, JS-only page) → tell
+  the user the page didn't render readable text and stop. Don't
+  guess from the URL alone.

--- a/internal/skills/embed/cookbook/stripe-recent-charges.md
+++ b/internal/skills/embed/cookbook/stripe-recent-charges.md
@@ -1,0 +1,75 @@
+---
+name: stripe-recent-charges
+description: "Show the most recent Stripe charges with status and dashboard links."
+---
+
+## When to use
+
+- The user asks "what came in today on Stripe" / "show recent
+  payments" / "any failed charges this week" — anything that maps
+  to a read-only Stripe lookup.
+- Avoid this skill when:
+  - The user wants to refund / capture / cancel a charge. Those
+    are write actions and need the existing approval gate; refer
+    them to a write-side skill (none ship in the cookbook today;
+    create one before doing the action).
+  - `STRIPE_API_KEY` (or `STRIPE_TEST_API_KEY` for test mode)
+    isn't configured. The tool will surface a clear error; relay
+    it back to the user with setup instructions instead of
+    retrying.
+
+## Steps
+
+1. Pick the right mode. If the user said "test" / "sandbox" /
+   "fake" / mentioned a test-only product, set `test_mode: true`.
+   Otherwise default to live.
+
+2. List charges:
+
+       stripe action: "list"
+              limit: 10        # raise to 25 if user wants "today's"
+              test_mode: <see step 1>
+
+   Returns JSON of the form:
+     - `charges`: array of `{id, amount, currency, status, created, url}`
+     - `has_more`: pagination flag
+
+3. Format for the user:
+   - One charge per line:
+       `<status>  <currency> <amount/100>  ·  <id>  ·  <created date>`
+   - Group by status when 3+ rows have the same value (helps the
+     "any failed?" intent quickly answer "yes/no, here's how many").
+   - Always include the dashboard URL on the row of any
+     `failed` / `disputed` / `requires_action` charge so the user
+     can click through.
+   - Trim to the most recent 5 unless the user specifically asked
+     for more — listing 10+ in chat is noisy.
+
+4. Offer drill-down. End with:
+   "Want details on one of these? (paste the id)"
+   On a follow-up id, call:
+
+       stripe action: "get"
+              id:     "<charge-id>"
+
+   Format the response as a short paragraph, not raw JSON.
+
+## Anti-patterns
+
+- Don't paginate automatically. `has_more=true` is signal that
+  there's more data, not an instruction to crawl. Tell the user
+  "+N older — paginate?" and wait.
+- Don't reformat amounts as floats from arithmetic. Stripe
+  amounts are integer minor-units (cents); divide by 100 only
+  for display, never for math the user might rely on.
+- Don't include the dashboard URL inline for every successful
+  charge — that's a wall of links nobody reads. Reserve URLs for
+  the rows that need a click.
+
+## Failure modes
+
+- Stripe returns 401 (bad key) → relay verbatim + suggest
+  `pan-agent doctor` to check key resolution.
+- Network timeout → suggest retrying in a moment; don't hammer.
+- Empty `charges` array → "No recent charges in <mode> mode" —
+  don't pretend there are some.


### PR DESCRIPTION
## Summary

Two starter skills that pair with already-shipped tools so users land on a useful default behaviour without writing skills first.

### \`clipboard-summarise\`

Reads the system clipboard via the cross-platform clipboard tool, detects content shape (URL / HTML / code / prose), and produces a short summary the user can paste back.

Anti-patterns: don't paraphrase a URL without fetching, don't summarise high-entropy strings (likely secrets).

Failure modes for clipboard-unavailable + paywall cases so the agent doesn't hallucinate when the source is empty.

### \`stripe-recent-charges\`

Pairs with the new Stripe tool (#58). Shows the most recent charges with status + dashboard links. Defaults to 5 rows in chat to avoid wall-of-text. Surfaces dashboard URLs only on rows that need a click (\`failed\` / \`disputed\` / \`requires_action\`).

Documents the \`test_mode\` → \`STRIPE_TEST_API_KEY\` routing so users know how to switch without re-reading the tool's parameter docs.

Anti-patterns: don't auto-paginate, don't math on amounts (integer minor-units), don't link every successful row.

Failure modes for 401 / network timeout / empty list.

## Format

Both skills follow the existing \`reminders-create\` / \`slack-summarise-channel\` template: \`name\` + \`description\` frontmatter, \"When to use\" up front, numbered Steps, anti-patterns, failure modes.

## Test plan

- The \`CookbookFS\` \`embed.FS\` picks them up automatically (\`//go:embed cookbook/*.md\` glob).
- \`TestCookbookFS_BundledSkillsHaveValidFrontmatter\` walks every file and confirms valid frontmatter — both new skills pass.
- \`go test ./...\` — 683/683 (no Go code changes).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)