### PR TITLE
feat(tools): WS#13.D Notion read-only tool

### DIFF
--- a/internal/tools/notion_tool.go
+++ b/internal/tools/notion_tool.go
@@ -1,0 +1,397 @@
+package tools
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/euraika-labs/pan-agent/internal/saaslinks"
+)
+
+// Phase 13 WS#13.D — Notion read-only tool.
+//
+// Surfaces three actions over the Notion API:
+//
+//   search       Search pages + databases by query string.
+//   get_page     Fetch one page's metadata + properties.
+//   get_block    Fetch one block's content (used for page bodies).
+//
+// Auth: NOTION_API_KEY env var. Format: secret_xxx (legacy) or
+// ntn_xxx (the post-Aug-2024 internal-integration prefix). Either
+// is accepted as a Bearer token.
+//
+// Output JSON includes a saaslinks.Notion URL for the looked-up
+// id so the receipt UI surfaces a click-through to notion.so.
+//
+// Read-only by design — no create/update/append actions in this
+// slice. Those land behind the existing approval gate when added.
+
+const (
+	notionAPIBase = "https://api.notion.com/v1"
+	// notionAPIVersion pins the Notion-Version header. Notion is
+	// strict about this — omit it and every call returns 400.
+	notionAPIVersion = "2022-06-28"
+)
+
+var notionAPIBaseFn = func() string { return notionAPIBase }
+
+var notionHTTPClient = &http.Client{Timeout: 15 * time.Second}
+
+// notionUUIDRe matches the two id shapes Notion accepts: bare 32
+// hex chars, or canonical UUID with dashes (8-4-4-4-12).
+var notionUUIDRe = regexp.MustCompile(
+	`^[0-9a-fA-F]{32}$|^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+
+// NotionTool is the read-only Notion API tool.
+type NotionTool struct{}
+
+func (NotionTool) Name() string { return "notion" }
+
+func (NotionTool) Description() string {
+	return "Read-only Notion API client. " +
+		"Actions: search (pages + databases by query), " +
+		"get_page (metadata + properties of one page), " +
+		"get_block (one block's content; used for page bodies). " +
+		"Returns JSON with the Notion data + a notion.so URL " +
+		"for human review. Requires NOTION_API_KEY env var."
+}
+
+func (NotionTool) Parameters() json.RawMessage {
+	return json.RawMessage(`{
+  "type": "object",
+  "required": ["action"],
+  "properties": {
+    "action": {
+      "type": "string",
+      "enum": ["search", "get_page", "get_block"]
+    },
+    "query": {
+      "type": "string",
+      "description": "search-only: substring query; matches page + database titles."
+    },
+    "id": {
+      "type": "string",
+      "description": "get_page / get_block-only: 32-hex or UUID-form id."
+    },
+    "filter": {
+      "type": "string",
+      "enum": ["page", "database"],
+      "description": "search-only: restrict to pages or databases. Default: both."
+    },
+    "limit": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 100,
+      "description": "search-only: max results. Default 10, cap 100."
+    }
+  }
+}`)
+}
+
+type notionParams struct {
+	Action string `json:"action"`
+	Query  string `json:"query,omitempty"`
+	ID     string `json:"id,omitempty"`
+	Filter string `json:"filter,omitempty"`
+	Limit  int    `json:"limit,omitempty"`
+}
+
+func (t NotionTool) Execute(ctx context.Context, params json.RawMessage) (*Result, error) {
+	var p notionParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return &Result{Error: fmt.Sprintf("invalid parameters: %v", err)}, nil
+	}
+	token := strings.TrimSpace(os.Getenv("NOTION_API_KEY"))
+	if token == "" {
+		return &Result{Error: "NOTION_API_KEY env var is required"}, nil
+	}
+
+	switch p.Action {
+	case "search":
+		return t.search(ctx, token, p)
+	case "get_page":
+		return t.getPage(ctx, token, p)
+	case "get_block":
+		return t.getBlock(ctx, token, p)
+	case "":
+		return &Result{Error: "action required (search|get_page|get_block)"}, nil
+	default:
+		return &Result{Error: fmt.Sprintf("unknown action %q", p.Action)}, nil
+	}
+}
+
+// ---------------------------------------------------------------------------
+// search — POST /v1/search
+// ---------------------------------------------------------------------------
+
+func (NotionTool) search(ctx context.Context, token string, p notionParams) (*Result, error) {
+	limit := p.Limit
+	if limit <= 0 {
+		limit = 10
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	body := map[string]any{
+		"query":     p.Query,
+		"page_size": limit,
+	}
+	if p.Filter != "" {
+		body["filter"] = map[string]string{
+			"property": "object",
+			"value":    p.Filter,
+		}
+	}
+	bb, _ := json.Marshal(body)
+
+	resp, err := notionPOST(ctx, notionAPIBaseFn()+"/search", token, bb)
+	if err != nil {
+		return &Result{Error: err.Error()}, nil
+	}
+
+	// Decode minimal shape — Notion returns rich payloads we don't
+	// need to surface in full. Pick the fields a search-result UI
+	// would actually render.
+	var sr struct {
+		Results []struct {
+			Object     string         `json:"object"`
+			ID         string         `json:"id"`
+			URL        string         `json:"url"`
+			Properties map[string]any `json:"properties,omitempty"`
+			Title      []struct {
+				PlainText string `json:"plain_text"`
+			} `json:"title,omitempty"`
+		} `json:"results"`
+		HasMore bool `json:"has_more"`
+	}
+	if err := json.Unmarshal(resp, &sr); err != nil {
+		return &Result{Error: fmt.Sprintf("decode search: %v", err)}, nil
+	}
+
+	type resultView struct {
+		Object string `json:"object"`
+		ID     string `json:"id"`
+		Title  string `json:"title,omitempty"`
+		URL    string `json:"url"`
+	}
+	out := struct {
+		Results []resultView `json:"results"`
+		HasMore bool         `json:"has_more"`
+	}{HasMore: sr.HasMore}
+	for _, r := range sr.Results {
+		view := resultView{Object: r.Object, ID: r.ID, URL: r.URL}
+		view.Title = extractNotionTitle(r.Title, r.Properties)
+		// Replace the API-provided URL with the saaslinks form when
+		// Notion gave us nothing (occasionally happens for shared
+		// pages). Otherwise keep the canonical URL Notion returns.
+		if view.URL == "" {
+			if u, ok := saaslinks.Notion(r.ID); ok {
+				view.URL = u
+			}
+		}
+		out.Results = append(out.Results, view)
+	}
+
+	js, _ := json.MarshalIndent(out, "", "  ")
+	return &Result{Output: string(js)}, nil
+}
+
+// ---------------------------------------------------------------------------
+// get_page — GET /v1/pages/<id>
+// ---------------------------------------------------------------------------
+
+func (NotionTool) getPage(ctx context.Context, token string, p notionParams) (*Result, error) {
+	if !isNotionID(p.ID) {
+		return &Result{Error: "id required (32-hex or UUID form)"}, nil
+	}
+	resp, err := notionGET(ctx, notionAPIBaseFn()+"/pages/"+p.ID, token)
+	if err != nil {
+		return &Result{Error: err.Error()}, nil
+	}
+	out := struct {
+		Page json.RawMessage `json:"page"`
+		URL  string          `json:"url"`
+	}{Page: resp}
+	if u, ok := saaslinks.Notion(p.ID); ok {
+		out.URL = u
+	}
+	js, _ := json.MarshalIndent(out, "", "  ")
+	return &Result{Output: string(js)}, nil
+}
+
+// ---------------------------------------------------------------------------
+// get_block — GET /v1/blocks/<id>/children?page_size=<limit>
+// ---------------------------------------------------------------------------
+
+func (NotionTool) getBlock(ctx context.Context, token string, p notionParams) (*Result, error) {
+	if !isNotionID(p.ID) {
+		return &Result{Error: "id required (32-hex or UUID form)"}, nil
+	}
+	limit := p.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	endpoint := fmt.Sprintf("%s/blocks/%s/children?page_size=%d",
+		notionAPIBaseFn(), p.ID, limit)
+	resp, err := notionGET(ctx, endpoint, token)
+	if err != nil {
+		return &Result{Error: err.Error()}, nil
+	}
+	out := struct {
+		Children json.RawMessage `json:"children"`
+		URL      string          `json:"url"`
+	}{Children: resp}
+	if u, ok := saaslinks.Notion(p.ID); ok {
+		out.URL = u
+	}
+	js, _ := json.MarshalIndent(out, "", "  ")
+	return &Result{Output: string(js)}, nil
+}
+
+// ---------------------------------------------------------------------------
+// HTTP helpers
+// ---------------------------------------------------------------------------
+
+func notionGET(ctx context.Context, endpoint, token string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	addNotionHeaders(req, token)
+	return doNotion(req)
+}
+
+func notionPOST(ctx context.Context, endpoint, token string, body []byte) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint,
+		bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	addNotionHeaders(req, token)
+	req.Header.Set("Content-Type", "application/json")
+	return doNotion(req)
+}
+
+func addNotionHeaders(req *http.Request, token string) {
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Notion-Version", notionAPIVersion)
+	req.Header.Set("Accept", "application/json")
+}
+
+func doNotion(req *http.Request) ([]byte, error) {
+	resp, err := notionHTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("notion: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 8*1024*1024))
+	if err != nil {
+		return nil, fmt.Errorf("read body: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("notion: status %d: %s",
+			resp.StatusCode, truncateNotionBody(string(body)))
+	}
+	return body, nil
+}
+
+// truncateNotionBody caps a body string for inclusion in an error
+// message. Local helper to avoid coupling to the Slack tool's
+// truncateForLog (the two tools' branches may merge in either
+// order; keeping helpers local avoids a follow-up dedupe slice).
+func truncateNotionBody(s string) string {
+	const max = 256
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "...(truncated)"
+}
+
+// ---------------------------------------------------------------------------
+// Misc
+// ---------------------------------------------------------------------------
+
+// isNotionID accepts 32-hex (no dashes) or canonical UUID forms.
+func isNotionID(s string) bool {
+	if len(s) > 36 {
+		return false
+	}
+	return notionUUIDRe.MatchString(s)
+}
+
+// extractNotionTitle pulls a human-readable title from the rich-
+// text array a Notion page returns. The actual location varies:
+//
+//   - Pages inside a database: properties["Name"].title[].plain_text
+//   - Top-level pages:         properties["title"].title[].plain_text
+//   - Databases:               title[].plain_text (top-level)
+//
+// We try the obvious candidates in order. Empty string means we
+// couldn't find a title (the search-result UI shows the id as a
+// fallback).
+func extractNotionTitle(top []struct {
+	PlainText string `json:"plain_text"`
+}, props map[string]any) string {
+	// Top-level title array (databases).
+	for _, t := range top {
+		if t.PlainText != "" {
+			return t.PlainText
+		}
+	}
+	if len(props) == 0 {
+		return ""
+	}
+	// Look for a property named "Name" or "title" with a title-array shape.
+	for _, key := range []string{"Name", "title", "Title"} {
+		if raw, ok := props[key]; ok {
+			if title := titleFromProp(raw); title != "" {
+				return title
+			}
+		}
+	}
+	// Fallback: scan every property for one with a title array.
+	for _, raw := range props {
+		if title := titleFromProp(raw); title != "" {
+			return title
+		}
+	}
+	return ""
+}
+
+func titleFromProp(raw any) string {
+	m, ok := raw.(map[string]any)
+	if !ok {
+		return ""
+	}
+	arr, ok := m["title"].([]any)
+	if !ok {
+		return ""
+	}
+	for _, item := range arr {
+		mm, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if pt, ok := mm["plain_text"].(string); ok && pt != "" {
+			return pt
+		}
+	}
+	return ""
+}
+
+var _ Tool = NotionTool{}
+
+func init() {
+	Register(NotionTool{})
+}

--- a/internal/tools/notion_tool_test.go
+++ b/internal/tools/notion_tool_test.go
@@ -1,0 +1,402 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Phase 13 WS#13.D — Notion tool tests. Hermetic via httptest.
+
+func installNotionFake(t *testing.T, h http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	prev := notionAPIBaseFn
+	notionAPIBaseFn = func() string { return srv.URL }
+	t.Cleanup(func() { notionAPIBaseFn = prev })
+	return srv
+}
+
+// ---------------------------------------------------------------------------
+// Auth + dispatch
+// ---------------------------------------------------------------------------
+
+func TestNotion_NoAPIKey(t *testing.T) {
+	t.Setenv("NOTION_API_KEY", "")
+	tool := NotionTool{}
+	out, _ := tool.Execute(context.Background(),
+		json.RawMessage(`{"action":"search","query":"x"}`))
+	if !strings.Contains(out.Error, "NOTION_API_KEY") {
+		t.Errorf("expected key error, got %+v", out)
+	}
+}
+
+func TestNotion_InvalidJSON(t *testing.T) {
+	t.Setenv("NOTION_API_KEY", "secret_fake")
+	tool := NotionTool{}
+	out, _ := tool.Execute(context.Background(), json.RawMessage(`{not-json`))
+	if !strings.Contains(out.Error, "invalid parameters") {
+		t.Errorf("expected parse error, got %+v", out)
+	}
+}
+
+func TestNotion_UnknownAction(t *testing.T) {
+	t.Setenv("NOTION_API_KEY", "secret_fake")
+	tool := NotionTool{}
+	out, _ := tool.Execute(context.Background(),
+		json.RawMessage(`{"action":"create_page"}`))
+	if !strings.Contains(out.Error, "unknown action") {
+		t.Errorf("expected unknown-action error, got %+v", out)
+	}
+}
+
+func TestNotion_EmptyAction(t *testing.T) {
+	t.Setenv("NOTION_API_KEY", "secret_fake")
+	tool := NotionTool{}
+	out, _ := tool.Execute(context.Background(), json.RawMessage(`{}`))
+	if !strings.Contains(out.Error, "action required") {
+		t.Errorf("expected action-required error, got %+v", out)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// search
+// ---------------------------------------------------------------------------
+
+func TestNotion_Search_HappyPath(t *testing.T) {
+	t.Setenv("NOTION_API_KEY", "secret_fake")
+	installNotionFake(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/search" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		if r.Method != "POST" {
+			t.Errorf("method = %q", r.Method)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer secret_fake" {
+			t.Errorf("auth = %q", got)
+		}
+		if got := r.Header.Get("Notion-Version"); got != notionAPIVersion {
+			t.Errorf("Notion-Version = %q", got)
+		}
+		body, _ := io.ReadAll(r.Body)
+		if !strings.Contains(string(body), `"page_size":10`) {
+			t.Errorf("body should include page_size:10, got %s", body)
+		}
+		fmt.Fprint(w, `{
+			"results": [
+				{
+					"object": "page",
+					"id": "abcdef0123456789abcdef0123456789",
+					"url": "https://notion.so/page-1",
+					"properties": {
+						"Name": {"title": [{"plain_text": "First Page"}]}
+					}
+				},
+				{
+					"object": "database",
+					"id": "11112222333344445555666677778888",
+					"url": "https://notion.so/db-1",
+					"title": [{"plain_text": "My Database"}]
+				}
+			],
+			"has_more": false
+		}`)
+	})
+
+	tool := NotionTool{}
+	out, _ := tool.Execute(context.Background(),
+		json.RawMessage(`{"action":"search","query":"hello"}`))
+	if out.Error != "" {
+		t.Fatalf("Error: %s", out.Error)
+	}
+
+	var resp struct {
+		Results []struct {
+			Object, ID, Title, URL string
+		}
+	}
+	if err := json.Unmarshal([]byte(out.Output), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Results) != 2 {
+		t.Fatalf("len = %d, want 2", len(resp.Results))
+	}
+	if resp.Results[0].Title != "First Page" {
+		t.Errorf("Title[0] = %q, want First Page", resp.Results[0].Title)
+	}
+	if resp.Results[1].Title != "My Database" {
+		t.Errorf("Title[1] = %q, want My Database", resp.Results[1].Title)
+	}
+}
+
+func TestNotion_Search_LimitClamp(t *testing.T) {
+	t.Setenv("NOTION_API_KEY", "secret_fake")
+	var captured int
+	installNotionFake(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req struct {
+			PageSize int `json:"page_size"`
+		}
+		_ = json.Unmarshal(body, &req)
+		captured = req.PageSize
+		fmt.Fprint(w, `{"results":[]}`)
+	})
+
+	tool := NotionTool{}
+	if _, err := tool.Execute(context.Background(),
+		json.RawMessage(`{"action":"search","query":"x","limit":500}`)); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if captured != 100 {
+		t.Errorf("limit clamp: got %d, want 100", captured)
+	}
+}
+
+func TestNotion_Search_FilterPage(t *testing.T) {
+	t.Setenv("NOTION_API_KEY", "secret_fake")
+	var capturedFilter string
+	installNotionFake(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req struct {
+			Filter map[string]string `json:"filter"`
+		}
+		_ = json.Unmarshal(body, &req)
+		capturedFilter = req.Filter["value"]
+		fmt.Fprint(w, `{"results":[]}`)
+	})
+	tool := NotionTool{}
+	if _, err := tool.Execute(context.Background(),
+		json.RawMessage(`{"action":"search","query":"x","filter":"page"}`)); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if capturedFilter != "page" {
+		t.Errorf("filter = %q, want page", capturedFilter)
+	}
+}
+
+func TestNotion_Search_HTTPError(t *testing.T) {
+	t.Setenv("NOTION_API_KEY", "secret_fake")
+	installNotionFake(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"object":"error","status":401,"code":"unauthorized","message":"API token is invalid"}`,
+			http.StatusUnauthorized)
+	})
+	tool := NotionTool{}
+	out, _ := tool.Execute(context.Background(),
+		json.RawMessage(`{"action":"search","query":"x"}`))
+	if !strings.Contains(out.Error, "401") {
+		t.Errorf("expected 401, got %+v", out)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// get_page
+// ---------------------------------------------------------------------------
+
+func TestNotion_GetPage_HappyPath(t *testing.T) {
+	t.Setenv("NOTION_API_KEY", "secret_fake")
+	installNotionFake(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/pages/abcdef0123456789abcdef0123456789" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		fmt.Fprint(w, `{"object":"page","id":"abcdef0123456789abcdef0123456789","properties":{}}`)
+	})
+	tool := NotionTool{}
+	out, _ := tool.Execute(context.Background(),
+		json.RawMessage(`{"action":"get_page","id":"abcdef0123456789abcdef0123456789"}`))
+	if out.Error != "" {
+		t.Fatalf("Error: %s", out.Error)
+	}
+	if !strings.Contains(out.Output, "abcdef0123456789") {
+		t.Errorf("output should contain page id: %s", out.Output)
+	}
+	if !strings.Contains(out.Output, "notion.so") {
+		t.Errorf("output should include notion.so URL: %s", out.Output)
+	}
+}
+
+func TestNotion_GetPage_BadID(t *testing.T) {
+	t.Setenv("NOTION_API_KEY", "secret_fake")
+	tool := NotionTool{}
+	for _, bad := range []string{
+		"",
+		"too-short",
+		"not-32-hex-but-padded-out-to-look-likeXXXXXX",
+		"contains_underscore_chars_____________",
+	} {
+		out, _ := tool.Execute(context.Background(),
+			json.RawMessage(fmt.Sprintf(`{"action":"get_page","id":%q}`, bad)))
+		if out.Error == "" {
+			t.Errorf("id %q: expected error", bad)
+		}
+	}
+}
+
+func TestNotion_GetPage_UUIDForm(t *testing.T) {
+	t.Setenv("NOTION_API_KEY", "secret_fake")
+	var capturedPath string
+	installNotionFake(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		fmt.Fprint(w, `{"object":"page"}`)
+	})
+	tool := NotionTool{}
+	out, _ := tool.Execute(context.Background(),
+		json.RawMessage(`{"action":"get_page","id":"abcdef01-2345-6789-abcd-ef0123456789"}`))
+	if out.Error != "" {
+		t.Fatalf("Error: %s", out.Error)
+	}
+	if !strings.HasPrefix(capturedPath, "/pages/abcdef01-") {
+		t.Errorf("path = %q", capturedPath)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// get_block
+// ---------------------------------------------------------------------------
+
+func TestNotion_GetBlock_HappyPath(t *testing.T) {
+	t.Setenv("NOTION_API_KEY", "secret_fake")
+	installNotionFake(t, func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/blocks/") {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		if !strings.HasSuffix(r.URL.Path, "/children") {
+			t.Errorf("path missing /children: %q", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("page_size"); got != "100" {
+			t.Errorf("page_size = %q, want 100", got)
+		}
+		fmt.Fprint(w, `{"results":[],"has_more":false}`)
+	})
+	tool := NotionTool{}
+	out, _ := tool.Execute(context.Background(),
+		json.RawMessage(`{"action":"get_block","id":"11112222333344445555666677778888"}`))
+	if out.Error != "" {
+		t.Fatalf("Error: %s", out.Error)
+	}
+}
+
+func TestNotion_GetBlock_LimitClamp(t *testing.T) {
+	t.Setenv("NOTION_API_KEY", "secret_fake")
+	var captured string
+	installNotionFake(t, func(w http.ResponseWriter, r *http.Request) {
+		captured = r.URL.Query().Get("page_size")
+		fmt.Fprint(w, `{"results":[]}`)
+	})
+	tool := NotionTool{}
+	if _, err := tool.Execute(context.Background(),
+		json.RawMessage(`{"action":"get_block","id":"abcdef0123456789abcdef0123456789","limit":500}`)); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if captured != "100" {
+		t.Errorf("limit clamp: got %q, want 100", captured)
+	}
+}
+
+func TestNotion_GetBlock_BadID(t *testing.T) {
+	t.Setenv("NOTION_API_KEY", "secret_fake")
+	tool := NotionTool{}
+	out, _ := tool.Execute(context.Background(),
+		json.RawMessage(`{"action":"get_block","id":"not-a-real-id"}`))
+	if out.Error == "" {
+		t.Error("expected bad-id error")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func TestNotion_RegisteredInRegistry(t *testing.T) {
+	tool, ok := Get("notion")
+	if !ok {
+		t.Fatal("notion tool not registered")
+	}
+	if tool.Name() != "notion" {
+		t.Errorf("Name = %q", tool.Name())
+	}
+}
+
+func TestNotion_IsNotionID(t *testing.T) {
+	cases := map[string]bool{
+		"abcdef0123456789abcdef0123456789":      true,
+		"abcdef01-2345-6789-abcd-ef0123456789":  true,
+		"ABCDEF0123456789ABCDEF0123456789":      true,
+		"":                                      false,
+		"too_short":                             false,
+		"abcdef0123456789abcdef012345678":       false, // 31 chars
+		"abcdef0123456789abcdef01234567890":     false, // 33 chars
+		"non-hex-but-padded-to-32-charszzzzzz!": false,
+		"abcdef01-2345-6789-abcd-ef012345678":   false,
+		"abcdef01_2345_6789_abcd_ef0123456789":  false, // underscores not allowed
+	}
+	for in, want := range cases {
+		if got := isNotionID(in); got != want {
+			t.Errorf("isNotionID(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestNotion_TitleExtraction(t *testing.T) {
+	cases := []struct {
+		name     string
+		topRaw   string
+		propsRaw string
+		want     string
+	}{
+		{
+			name:     "top-level title",
+			topRaw:   `[{"plain_text":"Top Title"}]`,
+			propsRaw: `{}`,
+			want:     "Top Title",
+		},
+		{
+			name:     "name property",
+			topRaw:   `[]`,
+			propsRaw: `{"Name":{"title":[{"plain_text":"Name Field"}]}}`,
+			want:     "Name Field",
+		},
+		{
+			name:     "title property fallback",
+			topRaw:   `[]`,
+			propsRaw: `{"Other":{"checkbox":true},"title":{"title":[{"plain_text":"Title Field"}]}}`,
+			want:     "Title Field",
+		},
+		{
+			name:     "no title anywhere",
+			topRaw:   `[]`,
+			propsRaw: `{"Description":{"rich_text":[]}}`,
+			want:     "",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var top []struct {
+				PlainText string `json:"plain_text"`
+			}
+			_ = json.Unmarshal([]byte(c.topRaw), &top)
+			var props map[string]any
+			_ = json.Unmarshal([]byte(c.propsRaw), &props)
+			got := extractNotionTitle(top, props)
+			if got != c.want {
+				t.Errorf("got %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestNotion_TruncateBody(t *testing.T) {
+	if got := truncateNotionBody("short"); got != "short" {
+		t.Errorf("short: %q", got)
+	}
+	long := strings.Repeat("x", 1000)
+	got := truncateNotionBody(long)
+	if !strings.HasSuffix(got, "(truncated)") {
+		t.Errorf("long not truncated: %s", got[len(got)-30:])
+	}
+}


### PR DESCRIPTION
## Summary

Surfaces three read-only actions over the Notion API:

- \`search\` — search pages + databases by query string
- \`get_page\` — fetch one page's metadata + properties
- \`get_block\` — fetch one block's children (used for page bodies)

Auth via \`NOTION_API_KEY\` env var. Format: \`secret_xxx\` (legacy) or \`ntn_xxx\` (post-Aug-2024 internal-integration prefix).

Output JSON includes the \`saaslinks.Notion\` URL so the receipt UI renders a click-through to notion.so. The API-provided URL is preferred when Notion returns one; \`saaslinks.Notion\` is the fallback for shared pages where Notion sometimes omits the URL.

## Implementation notes

- Stateless: \`NOTION_API_KEY\` re-read on each \`Execute\`.
- \`Notion-Version\` header pinned to \`2022-06-28\` (Notion is strict — omit it and every call returns 400).
- \`search\` clamps \`page_size\` to [1, 100], default 10. Optional \`filter\` restricts to \`page\` or \`database\`.
- \`get_page\` + \`get_block\` validate the id with \`isNotionID\` (32-hex or UUID-form, rejects underscores) **before** using it in a URL path.
- \`get_block\` calls \`/blocks/<id>/children\` with \`page_size\` cap 100.
- 8MB body cap via \`io.LimitReader\`; 15s HTTP timeout.
- \`extractNotionTitle\` walks the rich shapes Notion returns: top-level title array (databases) → \`properties[\"Name\"]\` → \`properties[\"title\"]\` → first title-shaped property.

## Test plan

22 hermetic tests via \`httptest\` covering:

- No API key, invalid JSON, unknown action, empty action
- \`search\` happy path: auth header, \`Notion-Version\`, body shape, title extraction from both database (top-level) + page (\`properties.Name\`) shapes
- \`search\` limit clamp, filter pass-through, HTTP 401 wraps status
- \`get_page\` happy path + notion.so URL injection
- \`get_page\` bad id (4 cases incl. wrong length, underscores)
- \`get_page\` UUID-form id round-trip
- \`get_block\` happy path (\`/blocks/<id>/children\` + page_size)
- \`get_block\` limit clamp, bad id
- Tool registered under \`\"notion\"\` in the default registry
- \`isNotionID\` truth table (10 cases)
- \`extractNotionTitle\` scenarios
- \`truncateNotionBody\` bounds

\`go test ./...\` — 705/705 pass. \`golangci-lint run ./internal/tools/\` — 0 issues.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)