### PR TITLE
feat(tools): WS#13.D Jira read-only tool

### DIFF
--- a/internal/tools/jira_tool.go
+++ b/internal/tools/jira_tool.go
@@ -1,0 +1,320 @@
+package tools
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/euraika-labs/pan-agent/internal/saaslinks"
+)
+
+// Phase 13 WS#13.D — Jira read-only tool.
+//
+// Surfaces three actions over Jira's Cloud REST API v3:
+//
+//   search    JQL-driven search across issues.
+//   get_issue Fetch one issue by key (e.g. "PAN-42").
+//   myself    Current authenticated user (auth probe / debug).
+//
+// Auth — two paths:
+//
+//   Cloud (atlassian.net)  → JIRA_HOST + JIRA_EMAIL + JIRA_API_TOKEN.
+//                            Basic auth with email:token base64-encoded.
+//   Self-hosted / Server   → JIRA_HOST + JIRA_BEARER. Bearer header with
+//                            a personal-access-token.
+//
+// Picking between the two: presence of JIRA_BEARER prefers bearer
+// auth; otherwise the Cloud Basic-auth path runs. Tells the user
+// what's missing when neither set is complete.
+//
+// Output JSON includes the saaslinks.Jira issue URL so the receipt
+// UI surfaces a click-through to the host's web UI.
+//
+// Read-only by design — no create/edit/transition/comment actions
+// in this slice. Those land behind the existing approval gate.
+
+const jiraAPIPath = "/rest/api/3"
+
+// jiraHostFn lets tests override the host. Production reads from env.
+var jiraHostFn = func() string { return strings.TrimSpace(os.Getenv("JIRA_HOST")) }
+
+// jiraBaseURLFn returns the full base URL the tool should hit.
+// Tests substitute an httptest server URL; production builds
+// "https://<host><jiraAPIPath>".
+var jiraBaseURLFn = func() string {
+	host := jiraHostFn()
+	if host == "" {
+		return ""
+	}
+	if !strings.HasPrefix(host, "http://") && !strings.HasPrefix(host, "https://") {
+		host = "https://" + host
+	}
+	return strings.TrimSuffix(host, "/") + jiraAPIPath
+}
+
+var jiraHTTPClient = &http.Client{Timeout: 15 * time.Second}
+
+// jiraIssueKeyRe matches the canonical PROJECT-NNN issue-key shape.
+// Atlassian docs: project key is 2-10 uppercase letters; issue
+// number is 1+ digits.
+var jiraIssueKeyRe = regexp.MustCompile(`^[A-Z][A-Z0-9]{1,9}-[1-9][0-9]{0,9}$`)
+
+// JiraTool is the read-only Jira API tool.
+type JiraTool struct{}
+
+func (JiraTool) Name() string { return "jira" }
+
+func (JiraTool) Description() string {
+	return "Read-only Jira Cloud API client. " +
+		"Actions: search (JQL-driven across issues), " +
+		"get_issue (one issue by key), " +
+		"myself (current user; auth probe). " +
+		"Returns JSON with the Jira data + a host web URL " +
+		"for human review. Requires JIRA_HOST + (JIRA_EMAIL + " +
+		"JIRA_API_TOKEN) for Cloud, or JIRA_BEARER for self-hosted."
+}
+
+func (JiraTool) Parameters() json.RawMessage {
+	return json.RawMessage(`{
+  "type": "object",
+  "required": ["action"],
+  "properties": {
+    "action": {
+      "type": "string",
+      "enum": ["search", "get_issue", "myself"]
+    },
+    "jql": {
+      "type": "string",
+      "description": "search-only: JQL query string (e.g. 'project = PAN AND status = \"In Progress\"')."
+    },
+    "issue_key": {
+      "type": "string",
+      "description": "get_issue-only: the issue key (e.g. 'PAN-42')."
+    },
+    "limit": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 100,
+      "description": "search-only: max issues. Default 25, cap 100."
+    },
+    "fields": {
+      "type": "string",
+      "description": "search-only: comma-separated field list. Default: 'summary,status,assignee,priority,updated'."
+    }
+  }
+}`)
+}
+
+type jiraParams struct {
+	Action   string `json:"action"`
+	JQL      string `json:"jql,omitempty"`
+	IssueKey string `json:"issue_key,omitempty"`
+	Limit    int    `json:"limit,omitempty"`
+	Fields   string `json:"fields,omitempty"`
+}
+
+// Execute dispatches the action. Auth + base URL probe runs first
+// so misconfiguration produces a clear error before we even look at
+// the action.
+func (t JiraTool) Execute(ctx context.Context, params json.RawMessage) (*Result, error) {
+	var p jiraParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return &Result{Error: fmt.Sprintf("invalid parameters: %v", err)}, nil
+	}
+	host := jiraHostFn()
+	if host == "" {
+		return &Result{Error: "JIRA_HOST env var is required"}, nil
+	}
+	auth, err := jiraAuth()
+	if err != nil {
+		return &Result{Error: err.Error()}, nil
+	}
+
+	switch p.Action {
+	case "search":
+		return t.search(ctx, host, auth, p)
+	case "get_issue":
+		return t.getIssue(ctx, host, auth, p)
+	case "myself":
+		return t.myself(ctx, auth)
+	case "":
+		return &Result{Error: "action required (search|get_issue|myself)"}, nil
+	default:
+		return &Result{Error: fmt.Sprintf("unknown action %q", p.Action)}, nil
+	}
+}
+
+// jiraAuth returns the value to put in the Authorization header.
+// Bearer wins when JIRA_BEARER is set; otherwise Basic email:token.
+func jiraAuth() (string, error) {
+	if bearer := strings.TrimSpace(os.Getenv("JIRA_BEARER")); bearer != "" {
+		return "Bearer " + bearer, nil
+	}
+	email := strings.TrimSpace(os.Getenv("JIRA_EMAIL"))
+	token := strings.TrimSpace(os.Getenv("JIRA_API_TOKEN"))
+	if email == "" || token == "" {
+		return "", fmt.Errorf(
+			"jira auth missing — set JIRA_BEARER for self-hosted, or JIRA_EMAIL + JIRA_API_TOKEN for Cloud")
+	}
+	enc := base64.StdEncoding.EncodeToString([]byte(email + ":" + token))
+	return "Basic " + enc, nil
+}
+
+// ---------------------------------------------------------------------------
+// search — GET /rest/api/3/search
+// ---------------------------------------------------------------------------
+
+func (JiraTool) search(ctx context.Context, host, auth string, p jiraParams) (*Result, error) {
+	if strings.TrimSpace(p.JQL) == "" {
+		return &Result{Error: "jql required"}, nil
+	}
+	limit := p.Limit
+	if limit <= 0 {
+		limit = 25
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	fields := strings.TrimSpace(p.Fields)
+	if fields == "" {
+		fields = "summary,status,assignee,priority,updated"
+	}
+
+	q := url.Values{}
+	q.Set("jql", p.JQL)
+	q.Set("maxResults", fmt.Sprintf("%d", limit))
+	q.Set("fields", fields)
+
+	body, err := jiraGET(ctx, jiraBaseURLFn()+"/search?"+q.Encode(), auth)
+	if err != nil {
+		return &Result{Error: err.Error()}, nil
+	}
+
+	var resp struct {
+		Issues []struct {
+			Key    string          `json:"key"`
+			Fields json.RawMessage `json:"fields"`
+		} `json:"issues"`
+		Total      int `json:"total"`
+		MaxResults int `json:"maxResults"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return &Result{Error: fmt.Sprintf("decode search: %v", err)}, nil
+	}
+
+	type issueView struct {
+		Key    string          `json:"key"`
+		URL    string          `json:"url"`
+		Fields json.RawMessage `json:"fields"`
+	}
+	out := struct {
+		Issues     []issueView `json:"issues"`
+		Total      int         `json:"total"`
+		MaxResults int         `json:"max_results"`
+	}{Total: resp.Total, MaxResults: resp.MaxResults}
+	for _, i := range resp.Issues {
+		view := issueView{Key: i.Key, Fields: i.Fields}
+		if u, ok := saaslinks.Jira(host, i.Key); ok {
+			view.URL = u
+		}
+		out.Issues = append(out.Issues, view)
+	}
+
+	js, _ := json.MarshalIndent(out, "", "  ")
+	return &Result{Output: string(js)}, nil
+}
+
+// ---------------------------------------------------------------------------
+// get_issue — GET /rest/api/3/issue/<key>
+// ---------------------------------------------------------------------------
+
+func (JiraTool) getIssue(ctx context.Context, host, auth string, p jiraParams) (*Result, error) {
+	if !isJiraIssueKey(p.IssueKey) {
+		return &Result{Error: "issue_key must match PROJECT-NNN (e.g. PAN-42)"}, nil
+	}
+
+	body, err := jiraGET(ctx, jiraBaseURLFn()+"/issue/"+p.IssueKey, auth)
+	if err != nil {
+		return &Result{Error: err.Error()}, nil
+	}
+
+	out := struct {
+		Issue json.RawMessage `json:"issue"`
+		URL   string          `json:"url"`
+	}{Issue: body}
+	if u, ok := saaslinks.Jira(host, p.IssueKey); ok {
+		out.URL = u
+	}
+	js, _ := json.MarshalIndent(out, "", "  ")
+	return &Result{Output: string(js)}, nil
+}
+
+// ---------------------------------------------------------------------------
+// myself — GET /rest/api/3/myself
+// ---------------------------------------------------------------------------
+
+func (JiraTool) myself(ctx context.Context, auth string) (*Result, error) {
+	body, err := jiraGET(ctx, jiraBaseURLFn()+"/myself", auth)
+	if err != nil {
+		return &Result{Error: err.Error()}, nil
+	}
+	return &Result{Output: string(body)}, nil
+}
+
+// ---------------------------------------------------------------------------
+// HTTP helpers
+// ---------------------------------------------------------------------------
+
+func jiraGET(ctx context.Context, endpoint, auth string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", auth)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := jiraHTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("jira: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 8*1024*1024))
+	if err != nil {
+		return nil, fmt.Errorf("read body: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("jira: status %d: %s",
+			resp.StatusCode, truncateJiraBody(string(body)))
+	}
+	return body, nil
+}
+
+func truncateJiraBody(s string) string {
+	const max = 256
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "...(truncated)"
+}
+
+func isJiraIssueKey(s string) bool {
+	if s == "" || len(s) > 32 {
+		return false
+	}
+	return jiraIssueKeyRe.MatchString(s)
+}
+
+var _ Tool = JiraTool{}
+
+func init() {
+	Register(JiraTool{})
+}

--- a/internal/tools/jira_tool_test.go
+++ b/internal/tools/jira_tool_test.go
@@ -1,0 +1,460 @@
+package tools
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Phase 13 WS#13.D — Jira tool tests. Hermetic via httptest.
+//
+// The tool reads JIRA_HOST + (JIRA_EMAIL + JIRA_API_TOKEN) or
+// JIRA_BEARER from env. Tests inject a fake host via jiraHostFn /
+// jiraBaseURLFn so the actual TCP target is the httptest server.
+
+func installJiraFake(t *testing.T, h http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	prevHost := jiraHostFn
+	prevBase := jiraBaseURLFn
+	jiraHostFn = func() string { return "test.atlassian.net" }
+	jiraBaseURLFn = func() string { return srv.URL }
+	t.Cleanup(func() {
+		jiraHostFn = prevHost
+		jiraBaseURLFn = prevBase
+	})
+	return srv
+}
+
+// ---------------------------------------------------------------------------
+// Auth + dispatch
+// ---------------------------------------------------------------------------
+
+func TestJira_NoHost(t *testing.T) {
+	prev := jiraHostFn
+	jiraHostFn = func() string { return "" }
+	t.Cleanup(func() { jiraHostFn = prev })
+	t.Setenv("JIRA_EMAIL", "a@b.c")
+	t.Setenv("JIRA_API_TOKEN", "tok")
+
+	tool := JiraTool{}
+	out, _ := tool.Execute(context.Background(),
+		json.RawMessage(`{"action":"myself"}`))
+	if !strings.Contains(out.Error, "JIRA_HOST") {
+		t.Errorf("expected host error, got %+v", out)
+	}
+}
+
+func TestJira_NoAuth(t *testing.T) {
+	installJiraFake(t, nil)
+	t.Setenv("JIRA_EMAIL", "")
+	t.Setenv("JIRA_API_TOKEN", "")
+	t.Setenv("JIRA_BEARER", "")
+
+	tool := JiraTool{}
+	out, _ := tool.Execute(context.Background(),
+		json.RawMessage(`{"action":"myself"}`))
+	if !strings.Contains(out.Error, "auth missing") {
+		t.Errorf("expected auth error, got %+v", out)
+	}
+}
+
+func TestJira_InvalidJSON(t *testing.T) {
+	installJiraFake(t, nil)
+	t.Setenv("JIRA_EMAIL", "a@b.c")
+	t.Setenv("JIRA_API_TOKEN", "tok")
+	tool := JiraTool{}
+	out, _ := tool.Execute(context.Background(), json.RawMessage(`{not-json`))
+	if !strings.Contains(out.Error, "invalid parameters") {
+		t.Errorf("expected parse error, got %+v", out)
+	}
+}
+
+func TestJira_UnknownAction(t *testing.T) {
+	installJiraFake(t, nil)
+	t.Setenv("JIRA_EMAIL", "a@b.c")
+	t.Setenv("JIRA_API_TOKEN", "tok")
+	tool := JiraTool{}
+	out, _ := tool.Execute(context.Background(),
+		json.RawMessage(`{"action":"create_issue"}`))
+	if !strings.Contains(out.Error, "unknown action") {
+		t.Errorf("expected unknown-action error, got %+v", out)
+	}
+}
+
+func TestJira_EmptyAction(t *testing.T) {
+	installJiraFake(t, nil)
+	t.Setenv("JIRA_EMAIL", "a@b.c")
+	t.Setenv("JIRA_API_TOKEN", "tok")
+	tool := JiraTool{}
+	out, _ := tool.Execute(context.Background(), json.RawMessage(`{}`))
+	if !strings.Contains(out.Error, "action required") {
+		t.Errorf("expected action-required error, got %+v", out)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Auth shapes
+// ---------------------------------------------------------------------------
+
+func TestJira_BearerAuth(t *testing.T) {
+	var captured string
+	installJiraFake(t, func(w http.ResponseWriter, r *http.Request) {
+		captured = r.Header.Get("Authorization")
+		fmt.Fprint(w, `{"accountId":"u-1"}`)
+	})
+	t.Setenv("JIRA_EMAIL", "")
+	t.Setenv("JIRA_API_TOKEN", "")
+	t.Setenv("JIRA_BEARER", "self-hosted-pat")
+
+	tool := JiraTool{}
+	if _, err := tool.Execute(context.Background(),
+		json.RawMessage(`{"action":"myself"}`)); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if captured != "Bearer self-hosted-pat" {
+		t.Errorf("auth = %q, want Bearer self-hosted-pat", captured)
+	}
+}
+
+func TestJira_BasicAuth(t *testing.T) {
+	var captured string
+	installJiraFake(t, func(w http.ResponseWriter, r *http.Request) {
+		captured = r.Header.Get("Authorization")
+		fmt.Fprint(w, `{"accountId":"u-1"}`)
+	})
+	t.Setenv("JIRA_BEARER", "")
+	t.Setenv("JIRA_EMAIL", "alice@example.com")
+	t.Setenv("JIRA_API_TOKEN", "secret-token")
+
+	tool := JiraTool{}
+	if _, err := tool.Execute(context.Background(),
+		json.RawMessage(`{"action":"myself"}`)); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	want := "Basic " + base64.StdEncoding.EncodeToString([]byte("alice@example.com:secret-token"))
+	if captured != want {
+		t.Errorf("auth = %q, want %q", captured, want)
+	}
+}
+
+func TestJira_BearerPreferredOverBasic(t *testing.T) {
+	var captured string
+	installJiraFake(t, func(w http.ResponseWriter, r *http.Request) {
+		captured = r.Header.Get("Authorization")
+		fmt.Fprint(w, `{"accountId":"u-1"}`)
+	})
+	t.Setenv("JIRA_BEARER", "bearer-wins")
+	t.Setenv("JIRA_EMAIL", "alice@example.com")
+	t.Setenv("JIRA_API_TOKEN", "tok")
+
+	tool := JiraTool{}
+	if _, err := tool.Execute(context.Background(),
+		json.RawMessage(`{"action":"myself"}`)); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.HasPrefix(captured, "Bearer ") {
+		t.Errorf("expected Bearer auth when JIRA_BEARER set, got %q", captured)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// search
+// ---------------------------------------------------------------------------
+
+func TestJira_Search_HappyPath(t *testing.T) {
+	t.Setenv("JIRA_EMAIL", "a@b.c")
+	t.Setenv("JIRA_API_TOKEN", "tok")
+	t.Setenv("JIRA_BEARER", "")
+	installJiraFake(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/search" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("jql"); got != "project = PAN" {
+			t.Errorf("jql = %q", got)
+		}
+		if got := r.URL.Query().Get("maxResults"); got != "25" {
+			t.Errorf("maxResults = %q, want 25 (default)", got)
+		}
+		fmt.Fprint(w, `{
+			"issues":[
+				{"key":"PAN-42","fields":{"summary":"Fix bug"}},
+				{"key":"PAN-43","fields":{"summary":"Add feature"}}
+			],
+			"total":2,"maxResults":25
+		}`)
+	})
+	tool := JiraTool{}
+	out, _ := tool.Execute(context.Background(),
+		json.RawMessage(`{"action":"search","jql":"project = PAN"}`))
+	if out.Error != "" {
+		t.Fatalf("Error: %s", out.Error)
+	}
+
+	var resp struct {
+		Issues []struct {
+			Key, URL string
+		}
+		Total int
+	}
+	if err := json.Unmarshal([]byte(out.Output), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Issues) != 2 {
+		t.Fatalf("len = %d, want 2", len(resp.Issues))
+	}
+	if resp.Total != 2 {
+		t.Errorf("total = %d, want 2", resp.Total)
+	}
+	if !strings.Contains(resp.Issues[0].URL, "PAN-42") {
+		t.Errorf("URL[0] should contain PAN-42: %q", resp.Issues[0].URL)
+	}
+	if !strings.Contains(resp.Issues[0].URL, "atlassian.net") {
+		t.Errorf("URL[0] should reference atlassian.net: %q", resp.Issues[0].URL)
+	}
+}
+
+func TestJira_Search_LimitClamp(t *testing.T) {
+	t.Setenv("JIRA_EMAIL", "a@b.c")
+	t.Setenv("JIRA_API_TOKEN", "tok")
+	t.Setenv("JIRA_BEARER", "")
+	var captured string
+	installJiraFake(t, func(w http.ResponseWriter, r *http.Request) {
+		captured = r.URL.Query().Get("maxResults")
+		fmt.Fprint(w, `{"issues":[],"total":0}`)
+	})
+	tool := JiraTool{}
+	if _, err := tool.Execute(context.Background(),
+		json.RawMessage(`{"action":"search","jql":"x","limit":500}`)); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if captured != "100" {
+		t.Errorf("maxResults clamp: got %q, want 100", captured)
+	}
+}
+
+func TestJira_Search_CustomFields(t *testing.T) {
+	t.Setenv("JIRA_EMAIL", "a@b.c")
+	t.Setenv("JIRA_API_TOKEN", "tok")
+	t.Setenv("JIRA_BEARER", "")
+	var captured string
+	installJiraFake(t, func(w http.ResponseWriter, r *http.Request) {
+		captured = r.URL.Query().Get("fields")
+		fmt.Fprint(w, `{"issues":[],"total":0}`)
+	})
+	tool := JiraTool{}
+	if _, err := tool.Execute(context.Background(),
+		json.RawMessage(`{"action":"search","jql":"x","fields":"summary,labels"}`)); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if captured != "summary,labels" {
+		t.Errorf("fields = %q", captured)
+	}
+}
+
+func TestJira_Search_DefaultFields(t *testing.T) {
+	t.Setenv("JIRA_EMAIL", "a@b.c")
+	t.Setenv("JIRA_API_TOKEN", "tok")
+	t.Setenv("JIRA_BEARER", "")
+	var captured string
+	installJiraFake(t, func(w http.ResponseWriter, r *http.Request) {
+		captured = r.URL.Query().Get("fields")
+		fmt.Fprint(w, `{"issues":[],"total":0}`)
+	})
+	tool := JiraTool{}
+	if _, err := tool.Execute(context.Background(),
+		json.RawMessage(`{"action":"search","jql":"x"}`)); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(captured, "summary") {
+		t.Errorf("default fields should include 'summary', got %q", captured)
+	}
+}
+
+func TestJira_Search_MissingJQL(t *testing.T) {
+	installJiraFake(t, nil)
+	t.Setenv("JIRA_EMAIL", "a@b.c")
+	t.Setenv("JIRA_API_TOKEN", "tok")
+	t.Setenv("JIRA_BEARER", "")
+	tool := JiraTool{}
+	out, _ := tool.Execute(context.Background(),
+		json.RawMessage(`{"action":"search"}`))
+	if !strings.Contains(out.Error, "jql required") {
+		t.Errorf("expected jql-required error, got %+v", out)
+	}
+}
+
+func TestJira_Search_HTTPError(t *testing.T) {
+	t.Setenv("JIRA_EMAIL", "a@b.c")
+	t.Setenv("JIRA_API_TOKEN", "tok")
+	t.Setenv("JIRA_BEARER", "")
+	installJiraFake(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"errorMessages":["JQL parse error"]}`, http.StatusBadRequest)
+	})
+	tool := JiraTool{}
+	out, _ := tool.Execute(context.Background(),
+		json.RawMessage(`{"action":"search","jql":"BAD JQL"}`))
+	if !strings.Contains(out.Error, "400") {
+		t.Errorf("expected 400 in error, got %+v", out)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// get_issue
+// ---------------------------------------------------------------------------
+
+func TestJira_GetIssue_HappyPath(t *testing.T) {
+	t.Setenv("JIRA_EMAIL", "a@b.c")
+	t.Setenv("JIRA_API_TOKEN", "tok")
+	t.Setenv("JIRA_BEARER", "")
+	installJiraFake(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/issue/PAN-42" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		fmt.Fprint(w, `{"key":"PAN-42","fields":{"summary":"Fix bug"}}`)
+	})
+	tool := JiraTool{}
+	out, _ := tool.Execute(context.Background(),
+		json.RawMessage(`{"action":"get_issue","issue_key":"PAN-42"}`))
+	if out.Error != "" {
+		t.Fatalf("Error: %s", out.Error)
+	}
+	if !strings.Contains(out.Output, "PAN-42") {
+		t.Errorf("output should contain key: %s", out.Output)
+	}
+	if !strings.Contains(out.Output, "atlassian.net") {
+		t.Errorf("output should include URL: %s", out.Output)
+	}
+}
+
+func TestJira_GetIssue_BadKey(t *testing.T) {
+	t.Setenv("JIRA_EMAIL", "a@b.c")
+	t.Setenv("JIRA_API_TOKEN", "tok")
+	t.Setenv("JIRA_BEARER", "")
+	tool := JiraTool{}
+	for _, bad := range []string{
+		"",
+		"lowercase-1",
+		"PAN_42", // underscore
+		"PAN 42", // space
+		"P-1",    // project too short (1 letter)
+		"PAN-",   // missing number
+		"-42",    // missing project
+		"PAN-0",  // leading-zero rule
+		"../etc/passwd",
+	} {
+		out, _ := tool.Execute(context.Background(),
+			json.RawMessage(fmt.Sprintf(`{"action":"get_issue","issue_key":%q}`, bad)))
+		if out.Error == "" {
+			t.Errorf("key %q: expected error", bad)
+		}
+	}
+}
+
+func TestJira_GetIssue_404(t *testing.T) {
+	t.Setenv("JIRA_EMAIL", "a@b.c")
+	t.Setenv("JIRA_API_TOKEN", "tok")
+	t.Setenv("JIRA_BEARER", "")
+	installJiraFake(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"errorMessages":["Issue does not exist"]}`, http.StatusNotFound)
+	})
+	tool := JiraTool{}
+	out, _ := tool.Execute(context.Background(),
+		json.RawMessage(`{"action":"get_issue","issue_key":"PAN-9999"}`))
+	if !strings.Contains(out.Error, "404") {
+		t.Errorf("expected 404 error, got %+v", out)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// myself
+// ---------------------------------------------------------------------------
+
+func TestJira_Myself_HappyPath(t *testing.T) {
+	t.Setenv("JIRA_EMAIL", "a@b.c")
+	t.Setenv("JIRA_API_TOKEN", "tok")
+	t.Setenv("JIRA_BEARER", "")
+	installJiraFake(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/myself" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		fmt.Fprint(w, `{"accountId":"u-1","displayName":"Alice","emailAddress":"a@b.c"}`)
+	})
+	tool := JiraTool{}
+	out, _ := tool.Execute(context.Background(),
+		json.RawMessage(`{"action":"myself"}`))
+	if out.Error != "" {
+		t.Fatalf("Error: %s", out.Error)
+	}
+	if !strings.Contains(out.Output, "u-1") {
+		t.Errorf("output should contain accountId: %s", out.Output)
+	}
+}
+
+func TestJira_Myself_401(t *testing.T) {
+	t.Setenv("JIRA_EMAIL", "a@b.c")
+	t.Setenv("JIRA_API_TOKEN", "wrong")
+	t.Setenv("JIRA_BEARER", "")
+	installJiraFake(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"errorMessages":["unauthorized"]}`, http.StatusUnauthorized)
+	})
+	tool := JiraTool{}
+	out, _ := tool.Execute(context.Background(),
+		json.RawMessage(`{"action":"myself"}`))
+	if !strings.Contains(out.Error, "401") {
+		t.Errorf("expected 401, got %+v", out)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func TestJira_RegisteredInRegistry(t *testing.T) {
+	tool, ok := Get("jira")
+	if !ok {
+		t.Fatal("jira tool not registered")
+	}
+	if tool.Name() != "jira" {
+		t.Errorf("Name = %q", tool.Name())
+	}
+}
+
+func TestJira_IsIssueKey(t *testing.T) {
+	cases := map[string]bool{
+		"PAN-42":           true,
+		"AB-1":             true,
+		"PROJ123-9":        true,
+		"":                 false,
+		"pan-42":           false, // lowercase
+		"P-1":              false, // 1-letter project
+		"PROJECT-":         false, // empty number
+		"-1":               false,
+		"PAN_42":           false,
+		"PAN 42":           false,
+		"PAN-0":            false, // leading zero rule (must start [1-9])
+		"PROJECTABCDEFG-1": false, // project >10 chars
+	}
+	for in, want := range cases {
+		if got := isJiraIssueKey(in); got != want {
+			t.Errorf("isJiraIssueKey(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestJira_TruncateBody(t *testing.T) {
+	if got := truncateJiraBody("short"); got != "short" {
+		t.Errorf("short: %q", got)
+	}
+	long := strings.Repeat("x", 1000)
+	got := truncateJiraBody(long)
+	if !strings.HasSuffix(got, "(truncated)") {
+		t.Errorf("not truncated: %s", got[len(got)-30:])
+	}
+}


### PR DESCRIPTION
## Summary

Surfaces three read-only actions over Jira's Cloud REST API v3:

- \`search\` — JQL-driven issue search
- \`get_issue\` — fetch one issue by key (e.g. \`PAN-42\`)
- \`myself\` — current authenticated user (auth probe)

## Auth — two paths

| Path | Env vars | Header |
|---|---|---|
| Cloud (atlassian.net) | \`JIRA_HOST\` + \`JIRA_EMAIL\` + \`JIRA_API_TOKEN\` | \`Basic <base64(email:token)>\` |
| Self-hosted / Server | \`JIRA_HOST\` + \`JIRA_BEARER\` | \`Bearer <PAT>\` |

Bearer wins when both env shapes are set. Tells the user what's missing when neither set is complete.

## Output

JSON includes a \`saaslinks.Jira\` issue URL for the host so the receipt UI renders a click-through.

## Implementation notes

- \`jiraHostFn\` + \`jiraBaseURLFn\` package vars let tests substitute an httptest server URL (host split from base so \`saaslinks.Jira\` still renders the production shape).
- \`search\` clamps \`maxResults\` to [1, 100], default 25. Default fields: \`summary,status,assignee,priority,updated\`.
- \`get_issue\` validates the issue key with \`isJiraIssueKey\` (\`^[A-Z][A-Z0-9]{1,9}-[1-9][0-9]{0,9}$\`) **before** using it in a URL path.
- 8MB body cap via \`io.LimitReader\`; 15s HTTP timeout.

## Test plan

22 hermetic tests via \`httptest\`:

- No host, no auth, invalid JSON, unknown action, empty action
- **Bearer auth, Basic auth, Bearer-preferred-over-Basic** (3 separate tests)
- \`search\` happy path with JQL, maxResults, default fields, URL injection
- \`search\` limit clamp, custom fields, default fields, missing JQL
- \`search\` HTTP 400 wraps status
- \`get_issue\` happy path + URL injection
- \`get_issue\` bad key (9 cases incl. lowercase, underscore, space, short project, missing number, leading zero, traversal)
- \`get_issue\` 404
- \`myself\` happy path, 401
- Tool registered under \`\"jira\"\` in the default registry
- \`isJiraIssueKey\` truth table (12 cases)
- \`truncateJiraBody\` bounds

\`go test ./...\` — 705/705 pass. \`golangci-lint run ./internal/tools/\` — 0 issues.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)