### PR TITLE
feat(skills): WS#13.E cookbook — notion-find-doc + jira-my-issues

### DIFF
--- a/internal/skills/embed/cookbook/jira-my-issues.md
+++ b/internal/skills/embed/cookbook/jira-my-issues.md
@@ -1,0 +1,76 @@
+---
+name: jira-my-issues
+description: "Show the current user's open Jira issues, grouped by project and status."
+---
+
+## When to use
+
+- The user asks "what's on my plate" / "my open Jira" / "what am I
+  working on" / "stand-up summary" — anything that maps to "my
+  issues that aren't Done".
+- Avoid this skill when:
+  - The user names a specific project or labels — use
+    `jira-search-by-jql` (write your own; this skill is the
+    "default standup" view).
+  - `JIRA_HOST` + auth env vars aren't set. The tool surfaces a
+    clear error; relay it back with setup instructions.
+
+## Steps
+
+1. Confirm the user reference. The stock JQL `assignee = currentUser()`
+   maps to whoever the JIRA_EMAIL or JIRA_BEARER token resolves to.
+   Verify by calling once:
+
+       jira action: "myself"
+
+   The `displayName` from the response is what you'll show as a
+   header. Skip this probe if you've already run it earlier in the
+   conversation — it's just a sanity check.
+
+2. Run the search:
+
+       jira action: "search"
+            jql:    "assignee = currentUser() AND statusCategory != Done ORDER BY updated DESC"
+            limit:  25
+            fields: "summary,status,priority,project,updated"
+
+3. Format the output. Group by `project.name`, then by `status.name`
+   within each project:
+
+       <ProjectName>  (<count>)
+         In Progress
+           PAN-42  Fix the bug · High · 2d ago
+           PAN-44  Refactor X · Medium · today
+         To Do
+           PAN-50  …
+
+   - Show `priority` only when it's High or Highest (the rest are
+     noise for a quick standup view).
+   - Format `updated` as a relative time ("2d ago", "today", "1w ago")
+     — Jira returns ISO 8601 strings.
+   - Always include the issue URL on the line for any High/Highest
+     priority row so the user can click straight through.
+
+4. Offer follow-ups:
+   - "Want the full description of <key>?" → `jira get_issue`.
+   - "Drop one to Done?" → write action; confirm + use a separate
+     write skill (not in this cookbook today).
+
+## Anti-patterns
+
+- Don't include `statusCategory = Done` issues. Standup views are
+  about WIP, not history.
+- Don't paginate. 25 items is plenty for a standup; if the user
+  has more, say "+N older — narrow the JQL?" and stop.
+- Don't math on `updated` timestamps. Jira returns ISO 8601 in the
+  user's TZ — pass through and let the rendering layer format
+  the relative time.
+
+## Failure modes
+
+- 401 → bad credentials. Suggest re-running `pan-agent doctor`.
+- 400 with "JQL parse error" → the assignee/statusCategory query
+  may not work on older Server installs. Tell the user + suggest
+  trying `assignee = "<your-email>"` instead.
+- Empty list → "All clear. Nothing assigned in flight." (Don't
+  invent items.)

--- a/internal/skills/embed/cookbook/notion-find-doc.md
+++ b/internal/skills/embed/cookbook/notion-find-doc.md
@@ -1,0 +1,63 @@
+---
+name: notion-find-doc
+description: "Find a Notion page or database by query and return a clickable result list."
+---
+
+## When to use
+
+- The user asks "find the doc about X" / "where's our runbook for Y"
+  / "search Notion for Z" — anything that maps to a Notion title-
+  search.
+- The user names a specific page id or url — skip search, jump
+  straight to `notion get_page`.
+- Avoid this skill when:
+  - `NOTION_API_KEY` isn't configured. The tool surfaces a clear
+    error; relay it back with setup instructions, don't retry.
+  - The user wants to *create* / *append* — those are write actions
+    + need approval gates not in this slice.
+
+## Steps
+
+1. Build the search query. Strip filler words ("the", "doc about",
+   "find me") and pass the substantive terms as `query`. If the
+   user's phrasing implies a specific object type, set the filter:
+     - "database" / "table" / "list of …" → `filter: "database"`
+     - "page" / "note" / "doc" → `filter: "page"`
+     - otherwise omit the filter (returns both).
+
+2. Call:
+
+       notion action: "search"
+              query:  "<terms>"
+              filter: "<page|database>"
+              limit:  10
+
+3. Format for the user. One result per line:
+   `<title> — <id_short> (<object>)  ·  <url>`
+   - Use the FIRST 8 hex chars of the id — full id is too noisy.
+   - Group consecutive results with empty/missing titles under a
+     "(untitled)" header so the user knows they exist without
+     wall-of-text.
+
+4. If the user's intent looks like "open the first match", call
+   `notion get_page` with the top result's id and summarise its
+   content. Otherwise end the turn with: "Want details on one of
+   these? (paste the id)".
+
+## Anti-patterns
+
+- Don't paginate when `has_more=true` — surface the count + cursor
+  string + suggest the user narrows the query.
+- Don't dump the raw `page` JSON. Pull title + last-edited + a
+  one-line excerpt of the first paragraph.
+- Don't follow links in the page body silently. If the user's
+  follow-up is "open the link in this page", confirm + then fetch
+  via the browser tool.
+
+## Failure modes
+
+- 401 / 403 → token missing the integration grant for that page.
+  Tell the user: "the integration isn't shared with this page —
+  open the page in Notion → Share → Add this connection".
+- Empty results → "Nothing matched. Wider terms? The query was: <q>"
+- Rate limited → back off + retry once with a small jitter.


### PR DESCRIPTION
## Summary

Two more starter skills paired with the WS#13.D read-only tools (Notion #61, Jira #62).

### \`notion-find-doc\`

Pairs with the Notion \`search\` action. Strips filler words, detects database-vs-page intent from phrasing (\"runbook\" / \"page\" / \"table\"), surfaces a short result list with truncated ids + URLs.

Anti-patterns: don't paginate when \`has_more\`, don't dump raw page JSON, don't silently follow page-body links.

Failure modes for 401 (integration not shared with the page), empty results, rate-limited.

### \`jira-my-issues\`

\"Standup view\" wrapped around \`assignee = currentUser() AND statusCategory != Done\`. Groups output by project then status, shows priority only when High/Highest, surfaces issue URLs on high-priority rows.

Anti-patterns: don't include \`Done\` items, don't paginate (25 is plenty for a standup), don't math on \`updated\` timestamps.

Failure modes for 401, 400 JQL-parse-error (Server compat fallback to \`assignee=<email>\`), empty list.

## Cookbook coverage

After this lands, every read-only tool we ship has a paired starter skill:

| Tool | Cookbook skill |
|---|---|
| clipboard | clipboard-summarise (#59) |
| stripe | stripe-recent-charges (#59) |
| slack | slack-summarise-channel (existing) |
| notion | notion-find-doc (this PR) |
| jira | jira-my-issues (this PR) |
| reminders | reminders-create (existing) |
| vscode | vscode-open-under-cursor (existing) |

## Test plan

Both skills follow the cookbook template (name + description frontmatter, When to use, numbered Steps, anti-patterns, failure modes). \`CookbookFS\` \`embed.FS\` picks them up via the \`//go:embed cookbook/*.md\` glob; \`TestCookbookFS_BundledSkillsHaveValidFrontmatter\` passes.

\`go test ./...\` — 683/683 (no Go code changes).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)