### PR TITLE
feat(cli): WS#13.D doctor — surface tool + RAG configuration state

### DIFF
--- a/cmd/pan-agent/doctor_tools.go
+++ b/cmd/pan-agent/doctor_tools.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Phase 13 WS#13.D — doctor sub-section: tool config probes.
+//
+// Each new read-only tool needs at least one env var to function.
+// The doctor surfaces the configuration state so the operator knows
+// at a glance which tools are usable on this host. None of the
+// checks fail — they're informational. A missing env var means the
+// tool returns a clear error at runtime; the doctor's job is to
+// surface that BEFORE the user tries to use the tool.
+
+// toolConfigChecks returns one doctorCheck per tool that ships
+// with env-var configuration. Pass is always true (the absence of
+// a tool's env var is documented as "optional"); the Detail string
+// carries the actual state.
+func toolConfigChecks() []doctorCheck {
+	var out []doctorCheck
+
+	// Stripe — STRIPE_API_KEY (live) or STRIPE_TEST_API_KEY (test).
+	{
+		live := strings.TrimSpace(os.Getenv("STRIPE_API_KEY"))
+		test := strings.TrimSpace(os.Getenv("STRIPE_TEST_API_KEY"))
+		switch {
+		case live != "" && test != "":
+			out = append(out, doctorCheck{
+				Label: "Tool: stripe", Pass: true,
+				Detail: "configured (live + test keys)",
+			})
+		case live != "":
+			out = append(out, doctorCheck{
+				Label: "Tool: stripe", Pass: true,
+				Detail: "configured (live only)",
+			})
+		case test != "":
+			out = append(out, doctorCheck{
+				Label: "Tool: stripe", Pass: true,
+				Detail: "configured (test only — set STRIPE_API_KEY for live mode)",
+			})
+		default:
+			out = append(out, doctorCheck{
+				Label: "Tool: stripe", Pass: true,
+				Detail: "not configured (set STRIPE_API_KEY to enable)",
+			})
+		}
+	}
+
+	// Slack — SLACK_BOT_TOKEN.
+	{
+		tok := strings.TrimSpace(os.Getenv("SLACK_BOT_TOKEN"))
+		if tok != "" {
+			out = append(out, doctorCheck{
+				Label: "Tool: slack", Pass: true, Detail: "configured",
+			})
+		} else {
+			out = append(out, doctorCheck{
+				Label: "Tool: slack", Pass: true,
+				Detail: "not configured (set SLACK_BOT_TOKEN to enable)",
+			})
+		}
+	}
+
+	// Notion — NOTION_API_KEY.
+	{
+		tok := strings.TrimSpace(os.Getenv("NOTION_API_KEY"))
+		if tok != "" {
+			out = append(out, doctorCheck{
+				Label: "Tool: notion", Pass: true, Detail: "configured",
+			})
+		} else {
+			out = append(out, doctorCheck{
+				Label: "Tool: notion", Pass: true,
+				Detail: "not configured (set NOTION_API_KEY to enable)",
+			})
+		}
+	}
+
+	// Jira — JIRA_HOST + (JIRA_BEARER OR JIRA_EMAIL+JIRA_API_TOKEN).
+	{
+		host := strings.TrimSpace(os.Getenv("JIRA_HOST"))
+		bearer := strings.TrimSpace(os.Getenv("JIRA_BEARER"))
+		email := strings.TrimSpace(os.Getenv("JIRA_EMAIL"))
+		tok := strings.TrimSpace(os.Getenv("JIRA_API_TOKEN"))
+		switch {
+		case host == "":
+			out = append(out, doctorCheck{
+				Label: "Tool: jira", Pass: true,
+				Detail: "not configured (set JIRA_HOST + auth to enable)",
+			})
+		case bearer != "":
+			out = append(out, doctorCheck{
+				Label: "Tool: jira", Pass: true,
+				Detail: fmt.Sprintf("configured (host=%s, bearer auth)", host),
+			})
+		case email != "" && tok != "":
+			out = append(out, doctorCheck{
+				Label: "Tool: jira", Pass: true,
+				Detail: fmt.Sprintf("configured (host=%s, basic auth)", host),
+			})
+		default:
+			out = append(out, doctorCheck{
+				Label: "Tool: jira", Pass: true,
+				Detail: fmt.Sprintf("partially configured (host=%s — missing JIRA_BEARER or JIRA_EMAIL+JIRA_API_TOKEN)", host),
+			})
+		}
+	}
+
+	// RAG embedder (Phase 13 WS#13.B) — surfaces the same env-var
+	// pair the gateway lifecycle reads on startup. Reported here so
+	// `doctor` users see whether semantic-recall context will be
+	// available when they start the gateway.
+	{
+		url := strings.TrimSpace(os.Getenv("PAN_AGENT_RAG_EMBEDDER_URL"))
+		model := strings.TrimSpace(os.Getenv("PAN_AGENT_RAG_EMBEDDER_MODEL"))
+		switch {
+		case url != "" && model != "":
+			out = append(out, doctorCheck{
+				Label: "RAG embedder", Pass: true,
+				Detail: fmt.Sprintf("configured (model=%s)", model),
+			})
+		case url != "" || model != "":
+			out = append(out, doctorCheck{
+				Label: "RAG embedder", Pass: true,
+				Detail: "partially configured (set BOTH PAN_AGENT_RAG_EMBEDDER_URL + _MODEL)",
+			})
+		default:
+			out = append(out, doctorCheck{
+				Label: "RAG embedder", Pass: true,
+				Detail: "not configured (chat works; semantic recall disabled)",
+			})
+		}
+	}
+
+	return out
+}

--- a/cmd/pan-agent/doctor_tools_test.go
+++ b/cmd/pan-agent/doctor_tools_test.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// Phase 13 WS#13.D — doctor tool-config probe tests. Verifies the
+// labels + detail strings each env-var configuration shape produces,
+// since the doctor's text output is operator-facing and a quiet
+// drift would be confusing.
+
+// findCheck returns the doctorCheck with the given label, or nil.
+func findCheck(checks []doctorCheck, label string) *doctorCheck {
+	for i := range checks {
+		if checks[i].Label == label {
+			return &checks[i]
+		}
+	}
+	return nil
+}
+
+// clearAllToolEnv strips every env var the tool checks read so each
+// test starts with a clean slate. t.Setenv("") sets to empty (which
+// is the "unset" path the helpers test for via TrimSpace == "").
+func clearAllToolEnv(t *testing.T) {
+	t.Helper()
+	for _, k := range []string{
+		"STRIPE_API_KEY", "STRIPE_TEST_API_KEY",
+		"SLACK_BOT_TOKEN",
+		"NOTION_API_KEY",
+		"JIRA_HOST", "JIRA_BEARER", "JIRA_EMAIL", "JIRA_API_TOKEN",
+		"PAN_AGENT_RAG_EMBEDDER_URL", "PAN_AGENT_RAG_EMBEDDER_MODEL",
+	} {
+		t.Setenv(k, "")
+	}
+}
+
+func TestToolConfigChecks_AllEmpty(t *testing.T) {
+	clearAllToolEnv(t)
+	checks := toolConfigChecks()
+	for _, c := range checks {
+		if !c.Pass {
+			t.Errorf("%s: Pass=false (tool checks must never fail)", c.Label)
+		}
+		if !strings.Contains(c.Detail, "not configured") &&
+			!strings.Contains(c.Detail, "partially configured") {
+			t.Errorf("%s: Detail = %q, expected 'not configured' message", c.Label, c.Detail)
+		}
+	}
+	// All five tools should appear.
+	for _, label := range []string{
+		"Tool: stripe", "Tool: slack", "Tool: notion", "Tool: jira",
+		"RAG embedder",
+	} {
+		if findCheck(checks, label) == nil {
+			t.Errorf("missing check %q", label)
+		}
+	}
+}
+
+func TestToolConfigChecks_StripeLiveOnly(t *testing.T) {
+	clearAllToolEnv(t)
+	t.Setenv("STRIPE_API_KEY", "sk_live_fake")
+	c := findCheck(toolConfigChecks(), "Tool: stripe")
+	if c == nil || !strings.Contains(c.Detail, "live only") {
+		t.Errorf("got %+v, want 'live only'", c)
+	}
+}
+
+func TestToolConfigChecks_StripeTestOnly(t *testing.T) {
+	clearAllToolEnv(t)
+	t.Setenv("STRIPE_TEST_API_KEY", "sk_test_fake")
+	c := findCheck(toolConfigChecks(), "Tool: stripe")
+	if c == nil || !strings.Contains(c.Detail, "test only") {
+		t.Errorf("got %+v, want 'test only'", c)
+	}
+}
+
+func TestToolConfigChecks_StripeBoth(t *testing.T) {
+	clearAllToolEnv(t)
+	t.Setenv("STRIPE_API_KEY", "sk_live_fake")
+	t.Setenv("STRIPE_TEST_API_KEY", "sk_test_fake")
+	c := findCheck(toolConfigChecks(), "Tool: stripe")
+	if c == nil || !strings.Contains(c.Detail, "live + test keys") {
+		t.Errorf("got %+v, want 'live + test keys'", c)
+	}
+}
+
+func TestToolConfigChecks_SlackConfigured(t *testing.T) {
+	clearAllToolEnv(t)
+	t.Setenv("SLACK_BOT_TOKEN", "xoxb-fake")
+	c := findCheck(toolConfigChecks(), "Tool: slack")
+	if c == nil || c.Detail != "configured" {
+		t.Errorf("got %+v, want 'configured'", c)
+	}
+}
+
+func TestToolConfigChecks_NotionConfigured(t *testing.T) {
+	clearAllToolEnv(t)
+	t.Setenv("NOTION_API_KEY", "secret_fake")
+	c := findCheck(toolConfigChecks(), "Tool: notion")
+	if c == nil || c.Detail != "configured" {
+		t.Errorf("got %+v, want 'configured'", c)
+	}
+}
+
+func TestToolConfigChecks_JiraNoHost(t *testing.T) {
+	clearAllToolEnv(t)
+	t.Setenv("JIRA_BEARER", "tok") // bearer set but no host
+	c := findCheck(toolConfigChecks(), "Tool: jira")
+	if c == nil || !strings.Contains(c.Detail, "JIRA_HOST") {
+		t.Errorf("got %+v, want host-missing message", c)
+	}
+}
+
+func TestToolConfigChecks_JiraBearer(t *testing.T) {
+	clearAllToolEnv(t)
+	t.Setenv("JIRA_HOST", "test.atlassian.net")
+	t.Setenv("JIRA_BEARER", "tok")
+	c := findCheck(toolConfigChecks(), "Tool: jira")
+	if c == nil || !strings.Contains(c.Detail, "bearer auth") {
+		t.Errorf("got %+v, want bearer auth", c)
+	}
+	if !strings.Contains(c.Detail, "test.atlassian.net") {
+		t.Errorf("Detail should include host: %q", c.Detail)
+	}
+}
+
+func TestToolConfigChecks_JiraBasic(t *testing.T) {
+	clearAllToolEnv(t)
+	t.Setenv("JIRA_HOST", "test.atlassian.net")
+	t.Setenv("JIRA_EMAIL", "a@b.c")
+	t.Setenv("JIRA_API_TOKEN", "tok")
+	c := findCheck(toolConfigChecks(), "Tool: jira")
+	if c == nil || !strings.Contains(c.Detail, "basic auth") {
+		t.Errorf("got %+v, want basic auth", c)
+	}
+}
+
+func TestToolConfigChecks_JiraPartial(t *testing.T) {
+	clearAllToolEnv(t)
+	t.Setenv("JIRA_HOST", "test.atlassian.net")
+	t.Setenv("JIRA_EMAIL", "a@b.c") // token missing
+	c := findCheck(toolConfigChecks(), "Tool: jira")
+	if c == nil || !strings.Contains(c.Detail, "partially configured") {
+		t.Errorf("got %+v, want partially-configured", c)
+	}
+}
+
+func TestToolConfigChecks_RAGFullyConfigured(t *testing.T) {
+	clearAllToolEnv(t)
+	t.Setenv("PAN_AGENT_RAG_EMBEDDER_URL", "http://x")
+	t.Setenv("PAN_AGENT_RAG_EMBEDDER_MODEL", "bge-small")
+	c := findCheck(toolConfigChecks(), "RAG embedder")
+	if c == nil || !strings.Contains(c.Detail, "model=bge-small") {
+		t.Errorf("got %+v, want configured w/ model name", c)
+	}
+}
+
+func TestToolConfigChecks_RAGPartial(t *testing.T) {
+	clearAllToolEnv(t)
+	t.Setenv("PAN_AGENT_RAG_EMBEDDER_URL", "http://x") // model missing
+	c := findCheck(toolConfigChecks(), "RAG embedder")
+	if c == nil || !strings.Contains(c.Detail, "partially configured") {
+		t.Errorf("got %+v, want partially-configured", c)
+	}
+}
+
+func TestToolConfigChecks_AllPass(t *testing.T) {
+	// Even with weird/wrong values, Pass should always be true —
+	// tool checks are informational, not gating.
+	clearAllToolEnv(t)
+	t.Setenv("STRIPE_API_KEY", "weird")
+	t.Setenv("SLACK_BOT_TOKEN", "weird")
+	t.Setenv("NOTION_API_KEY", "weird")
+	t.Setenv("JIRA_HOST", "weird")
+	t.Setenv("JIRA_BEARER", "weird")
+	checks := toolConfigChecks()
+	for _, c := range checks {
+		if !c.Pass {
+			t.Errorf("%s: Pass=false (informational checks must always pass)", c.Label)
+		}
+	}
+}

--- a/cmd/pan-agent/main.go
+++ b/cmd/pan-agent/main.go
@@ -451,6 +451,14 @@ func doctorHealthChecks(jsonOut bool) error {
 		add("CSP violations log", true, "(empty or absent)")
 	}
 
+	// 8. Tool configuration probes (Phase 13 WS#13.D). Reports whether
+	// each optional read-only tool's env vars are populated. None of
+	// these are fatal — tools without their env vars simply 503/error
+	// at runtime, but it's nice for the doctor to surface "you have
+	// JIRA_HOST set, but JIRA_API_TOKEN is missing" so the operator
+	// knows what to fix BEFORE they try to use the tool.
+	checks = append(checks, toolConfigChecks()...)
+
 	if jsonOut {
 		out := map[string]any{
 			"checks": checks,


### PR DESCRIPTION
## Summary

Extends \`pan-agent doctor\` to report the configuration state of each optional tool's env vars + the RAG embedder. Operators see at a glance which tools are usable on this host, **before** they try to invoke one and get a runtime error.

## Five new checks

| Check | Reads | States |
|---|---|---|
| Tool: stripe | \`STRIPE_API_KEY\` / \`STRIPE_TEST_API_KEY\` | not configured / live only / test only / live + test |
| Tool: slack | \`SLACK_BOT_TOKEN\` | configured / not configured |
| Tool: notion | \`NOTION_API_KEY\` | configured / not configured |
| Tool: jira | \`JIRA_HOST\` + auth | not configured / bearer auth / basic auth / partial |
| RAG embedder | \`PAN_AGENT_RAG_EMBEDDER_{URL,MODEL}\` | configured / partial / not configured |

## Design choices

- **All tool checks \`Pass: true\` unconditionally.** Tools without env vars aren't an error, they're \"not configured\". The Detail string carries the actual state. This avoids breaking CI that runs \`pan-agent doctor\` and expects exit 0 on a host that hasn't opted into every tool.
- Detail strings include enough context to fix the problem: missing-key messages name the env var; partial-Jira messages list which \`JIRA_*\` var pair is missing.

## Test plan

13 new tests covering:
- All-empty (every check appears, Pass=true, Detail says \"not configured\")
- Stripe: live-only / test-only / both
- Slack, Notion: configured states
- Jira: bearer auth / basic auth / partial (host + email no token) / no host
- RAG: fully configured / partial (URL only)
- **All-pass invariant**: even with weird values, Pass stays true

\`go test ./...\` — 696/696 pass. \`golangci-lint run ./cmd/pan-agent/\` — 0 issues.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)