### PR TITLE
feat(cli): pan-agent tools list + describe subcommands

### DIFF
--- a/cmd/pan-agent/main.go
+++ b/cmd/pan-agent/main.go
@@ -7,6 +7,7 @@
 //	pan-agent version                                   Print version info
 //	pan-agent doctor                                    Check system health
 //	pan-agent skill  verify <bundle-path>               Verify a marketplace bundle
+//	pan-agent tools  list                               List registered tools
 //
 // Default (no subcommand): serve
 package main
@@ -70,8 +71,10 @@ func run(args []string) error {
 		return cmdMigrateOffice(args)
 	case "skill":
 		return cmdSkill(args)
+	case "tools":
+		return cmdTools(args)
 	default:
-		return fmt.Errorf("unknown subcommand %q\n\nUsage: pan-agent <serve|chat|version|doctor|migrate-office|skill>", sub)
+		return fmt.Errorf("unknown subcommand %q\n\nUsage: pan-agent <serve|chat|version|doctor|migrate-office|skill|tools>", sub)
 	}
 }
 

--- a/cmd/pan-agent/tools.go
+++ b/cmd/pan-agent/tools.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/euraika-labs/pan-agent/internal/tools"
+)
+
+// cmdTools dispatches the `pan-agent tools <action>` subcommands.
+//
+//	pan-agent tools list           List every registered tool.
+//	pan-agent tools describe <n>   Print the JSON Schema parameters for a tool.
+//
+// "tools" is a sibling of "skill" — both are introspection surfaces
+// for power users who don't want to spin up the desktop UI.
+func cmdTools(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf(
+			"missing tools action — usage: pan-agent tools [list|describe]")
+	}
+	action := args[0]
+	rest := args[1:]
+	switch action {
+	case "list":
+		return cmdToolsList(rest)
+	case "describe":
+		return cmdToolsDescribe(rest)
+	default:
+		return fmt.Errorf("unknown tools action %q — usage: pan-agent tools [list|describe]",
+			action)
+	}
+}
+
+// cmdToolsList enumerates registered tools and prints
+// "<name>\t<description>" lines, sorted by name. --json emits a
+// machine-readable array for scripting.
+func cmdToolsList(args []string) error {
+	fs := flag.NewFlagSet("tools list", flag.ContinueOnError)
+	jsonOut := fs.Bool("json", false, "emit JSON array instead of plain text")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	all := tools.All()
+	names := make([]string, 0, len(all))
+	for n := range all {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+
+	if *jsonOut {
+		type toolView struct {
+			Name        string `json:"name"`
+			Description string `json:"description"`
+		}
+		out := make([]toolView, 0, len(names))
+		for _, n := range names {
+			t := all[n]
+			out = append(out, toolView{
+				Name: t.Name(), Description: t.Description(),
+			})
+		}
+		b, _ := json.MarshalIndent(out, "", "  ")
+		fmt.Println(string(b))
+		return nil
+	}
+
+	if len(names) == 0 {
+		fmt.Println("(no tools registered)")
+		return nil
+	}
+	for _, n := range names {
+		t := all[n]
+		// Single-line description: collapse internal newlines + trim
+		// so the columnar layout stays clean. Long descriptions are
+		// truncated to 100 chars with " …" so the user knows there's
+		// more to see (via `tools describe`).
+		desc := strings.ReplaceAll(t.Description(), "\n", " ")
+		desc = strings.Join(strings.Fields(desc), " ")
+		const max = 100
+		if len(desc) > max {
+			desc = desc[:max] + " …"
+		}
+		fmt.Printf("%-22s  %s\n", n, desc)
+	}
+	return nil
+}
+
+// cmdToolsDescribe prints the full description + JSON Schema
+// Parameters block for one tool. Useful when wiring up a new
+// invocation site or debugging a "tool said X failed" loop.
+func cmdToolsDescribe(args []string) error {
+	fs := flag.NewFlagSet("tools describe", flag.ContinueOnError)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() < 1 {
+		return fmt.Errorf(
+			"missing tool name — usage: pan-agent tools describe <name>")
+	}
+	name := fs.Arg(0)
+	t, ok := tools.Get(name)
+	if !ok {
+		return fmt.Errorf("no such tool %q (try `pan-agent tools list`)", name)
+	}
+
+	// Pretty-print the schema if it's valid JSON; fall back to
+	// raw output otherwise (a bug in the tool author's schema
+	// shouldn't break the CLI).
+	var pretty interface{}
+	rawSchema := t.Parameters()
+	if err := json.Unmarshal(rawSchema, &pretty); err == nil {
+		if b, err := json.MarshalIndent(pretty, "", "  "); err == nil {
+			rawSchema = b
+		}
+	}
+
+	fmt.Printf("Tool:        %s\n", t.Name())
+	fmt.Printf("Description: %s\n", t.Description())
+	fmt.Printf("\nParameters (JSON Schema):\n%s\n", rawSchema)
+	return nil
+}

--- a/cmd/pan-agent/tools_test.go
+++ b/cmd/pan-agent/tools_test.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+// Phase 13 WS#13.D — `pan-agent tools list/describe` tests.
+//
+// The tool registry registers via init() — every test in this
+// package runs against the real Default registry, so the tools
+// shipped in internal/tools (clarify, browser, stripe, slack,
+// notion, jira, etc.) are all visible.
+
+// captureStdout runs fn with os.Stdout redirected to a buffer + returns
+// the captured bytes. Used because the cmdTools helpers print to stdout
+// directly.
+func captureStdout(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- fn() }()
+
+	// Closing the writer unblocks the reader. We have to do that
+	// AFTER the function returns, so we drain the function first.
+	runErr := <-errCh
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	return buf.String(), runErr
+}
+
+// ---------------------------------------------------------------------------
+// Top-level dispatch
+// ---------------------------------------------------------------------------
+
+func TestCmdTools_NoAction(t *testing.T) {
+	if err := cmdTools(nil); err == nil {
+		t.Error("expected missing-action error")
+	}
+}
+
+func TestCmdTools_UnknownAction(t *testing.T) {
+	if err := cmdTools([]string{"banana"}); err == nil ||
+		!strings.Contains(err.Error(), "unknown") {
+		t.Errorf("got %v, want unknown-action error", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// list
+// ---------------------------------------------------------------------------
+
+func TestCmdToolsList_Plain(t *testing.T) {
+	out, err := captureStdout(t, func() error {
+		return cmdToolsList(nil)
+	})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	// Sanity: a few stable core tools must always appear. The WS#13.D
+	// additions (stripe/slack/notion/jira) live on parallel branches
+	// at the time this test was written; checking for them here would
+	// couple this slice to merge order. Stick to tools that are on
+	// main today.
+	for _, want := range []string{"clarify", "browser"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing tool %q\n%s", want, out)
+		}
+	}
+}
+
+func TestCmdToolsList_SortedOutput(t *testing.T) {
+	out, err := captureStdout(t, func() error {
+		return cmdToolsList(nil)
+	})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	// Each line is "<name>  <description>". Pull names + verify sorted.
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	var names []string
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) > 0 {
+			names = append(names, fields[0])
+		}
+	}
+	for i := 1; i < len(names); i++ {
+		if names[i] < names[i-1] {
+			t.Errorf("output not sorted: %q before %q",
+				names[i-1], names[i])
+			break
+		}
+	}
+}
+
+func TestCmdToolsList_JSON(t *testing.T) {
+	out, err := captureStdout(t, func() error {
+		return cmdToolsList([]string{"--json"})
+	})
+	if err != nil {
+		t.Fatalf("list --json: %v", err)
+	}
+	var arr []struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+	}
+	if err := json.Unmarshal([]byte(out), &arr); err != nil {
+		t.Fatalf("output not valid JSON: %v\n%s", err, out)
+	}
+	if len(arr) == 0 {
+		t.Fatal("JSON output has zero tools")
+	}
+	for _, t2 := range arr {
+		if t2.Name == "" {
+			t.Errorf("tool with empty name: %+v", t2)
+		}
+		if t2.Description == "" {
+			t.Errorf("tool %q: empty description", t2.Name)
+		}
+	}
+}
+
+func TestCmdToolsList_DescriptionTruncation(t *testing.T) {
+	out, err := captureStdout(t, func() error {
+		return cmdToolsList(nil)
+	})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	// No single output line should exceed ~140 chars (22 col name +
+	// 2 sep + 100 desc + " …" + a small fudge factor).
+	for _, line := range strings.Split(out, "\n") {
+		if len(line) > 200 {
+			t.Errorf("line longer than expected truncation: %d chars\n%s",
+				len(line), line)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// describe
+// ---------------------------------------------------------------------------
+
+func TestCmdToolsDescribe_HappyPath(t *testing.T) {
+	out, err := captureStdout(t, func() error {
+		return cmdToolsDescribe([]string{"clarify"})
+	})
+	if err != nil {
+		t.Fatalf("describe clarify: %v", err)
+	}
+	if !strings.Contains(out, "Tool:") || !strings.Contains(out, "clarify") {
+		t.Errorf("output missing Tool: header for clarify\n%s", out)
+	}
+	if !strings.Contains(out, "Parameters") {
+		t.Errorf("output missing Parameters block\n%s", out)
+	}
+	// The schema must be valid JSON. Find the section and parse it.
+	idx := strings.Index(out, "{")
+	if idx < 0 {
+		t.Fatalf("no JSON found in output: %s", out)
+	}
+	var schema map[string]any
+	if err := json.Unmarshal([]byte(out[idx:]), &schema); err != nil {
+		t.Errorf("schema is not valid JSON: %v", err)
+	}
+}
+
+func TestCmdToolsDescribe_NoArg(t *testing.T) {
+	if err := cmdToolsDescribe(nil); err == nil {
+		t.Error("expected missing-name error")
+	}
+}
+
+func TestCmdToolsDescribe_UnknownTool(t *testing.T) {
+	if err := cmdToolsDescribe([]string{"no-such-tool-exists"}); err == nil {
+		t.Error("expected no-such-tool error")
+	}
+}

--- a/cmd/pan-agent/tools_test.go
+++ b/cmd/pan-agent/tools_test.go
@@ -19,6 +19,12 @@ import (
 // captureStdout runs fn with os.Stdout redirected to a buffer + returns
 // the captured bytes. Used because the cmdTools helpers print to stdout
 // directly.
+//
+// Implementation note: the pipe buffer is small (≈4KB on Windows). If
+// fn writes more output than fits, it'll block on the write — so the
+// drain goroutine has to run CONCURRENTLY with fn, not after it. Caught
+// by Windows CI on PR #65 where TestCmdToolsList_JSON hung because the
+// JSON output exceeded the pipe buffer.
 func captureStdout(t *testing.T, fn func() error) (string, error) {
 	t.Helper()
 	old := os.Stdout
@@ -28,17 +34,18 @@ func captureStdout(t *testing.T, fn func() error) (string, error) {
 	}
 	os.Stdout = w
 
-	errCh := make(chan error, 1)
-	go func() { errCh <- fn() }()
+	var buf bytes.Buffer
+	copyDone := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(&buf, r)
+		close(copyDone)
+	}()
 
-	// Closing the writer unblocks the reader. We have to do that
-	// AFTER the function returns, so we drain the function first.
-	runErr := <-errCh
-	w.Close()
+	runErr := fn()
+	_ = w.Close() // unblocks the io.Copy goroutine
+	<-copyDone
 	os.Stdout = old
 
-	var buf bytes.Buffer
-	_, _ = io.Copy(&buf, r)
 	return buf.String(), runErr
 }
 


### PR DESCRIPTION
## Summary

Power-user introspection surface for the tool registry — sibling of the existing \`skill\` subcommand.

\`\`\`
pan-agent tools list [--json]
pan-agent tools describe <name>
\`\`\`

## Behaviour

### \`tools list\`

Enumerates every registered tool. Plain mode prints \`<name>  <description>\` lines, sorted by name. \`--json\` emits \`[{name, description}, ...]\` for scripting.

Descriptions truncated at 100 chars with \" …\" so the columnar layout stays clean.

### \`tools describe <name>\`

Prints the tool's full description + JSON Schema parameters block. Pretty-prints valid schemas; falls back to raw output on author-side schema bugs.

## Use cases

- Writing skills that invoke a tool — peek the schema without spinning up the desktop UI.
- Debugging \"tool said X failed\" loops — confirm the tool is registered + see its full description.
- CI scripts that diff the available tool set against a known fixture.

## Test plan

9 new tests:
- Top-level dispatch: missing action, unknown action
- \`list\`: plain output contains stable core tools (\`clarify\`, \`browser\`); names appear sorted; \`--json\` round-trips through \`json.Unmarshal\`; description truncation cap holds
- \`describe\`: happy path against a stable core tool; missing name; unknown tool name

Stdout-capture helper because the helpers print directly. Pipe + goroutine pattern handles flushed-stdin cases + EOFs correctly.

\`go test ./...\` — 692/692 pass. \`golangci-lint run ./cmd/pan-agent/\` — 0 issues.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)