### PR TITLE
feat(cli): pan-agent rag stats + purge subcommands

### DIFF
--- a/cmd/pan-agent/main.go
+++ b/cmd/pan-agent/main.go
@@ -7,6 +7,7 @@
 //	pan-agent version                                   Print version info
 //	pan-agent doctor                                    Check system health
 //	pan-agent skill  verify <bundle-path>               Verify a marketplace bundle
+//	pan-agent rag    stats | purge                      Inspect / purge the semantic index
 //
 // Default (no subcommand): serve
 package main
@@ -70,8 +71,10 @@ func run(args []string) error {
 		return cmdMigrateOffice(args)
 	case "skill":
 		return cmdSkill(args)
+	case "rag":
+		return cmdRAG(args)
 	default:
-		return fmt.Errorf("unknown subcommand %q\n\nUsage: pan-agent <serve|chat|version|doctor|migrate-office|skill>", sub)
+		return fmt.Errorf("unknown subcommand %q\n\nUsage: pan-agent <serve|chat|version|doctor|migrate-office|skill|rag>", sub)
 	}
 }
 

--- a/cmd/pan-agent/rag.go
+++ b/cmd/pan-agent/rag.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"sort"
+
+	"github.com/euraika-labs/pan-agent/internal/paths"
+	"github.com/euraika-labs/pan-agent/internal/storage"
+)
+
+// cmdRAG dispatches `pan-agent rag <action>` — operational
+// commands over the WS#13.B semantic-search index.
+//
+//	pan-agent rag stats              Counts per session + model totals.
+//	pan-agent rag purge --session=X  Drop every embedding tied to one session.
+//
+// `pan-agent rag reindex` (delete-and-rebuild) is intentionally
+// out of scope for this slice — re-embedding is a heavy operation
+// that should run inside the gateway's watcher with its rate-limit
+// + checkpoint logic, not from a fire-and-forget CLI.
+func cmdRAG(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf(
+			"missing rag action — usage: pan-agent rag [stats|purge]")
+	}
+	action := args[0]
+	rest := args[1:]
+	switch action {
+	case "stats":
+		return cmdRAGStats(rest)
+	case "purge":
+		return cmdRAGPurge(rest)
+	default:
+		return fmt.Errorf("unknown rag action %q — usage: pan-agent rag [stats|purge]",
+			action)
+	}
+}
+
+// cmdRAGStats reports per-session embedding counts. Useful for a
+// power user to see "what's indexed?" without firing up the desktop.
+func cmdRAGStats(args []string) error {
+	fs := flag.NewFlagSet("rag stats", flag.ContinueOnError)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	db, err := storage.Open(paths.StateDB())
+	if err != nil {
+		return fmt.Errorf("open db: %w", err)
+	}
+	defer db.Close()
+
+	sessions, models, total, err := ragStatsQuery(db)
+	if err != nil {
+		return fmt.Errorf("rag stats: %w", err)
+	}
+
+	fmt.Printf("rag_embeddings: %d row(s) total\n", total)
+	if total == 0 {
+		fmt.Println("(no embeddings yet — start the gateway with PAN_AGENT_RAG_EMBEDDER_URL set + chat for a bit)")
+		return nil
+	}
+
+	if len(models) > 0 {
+		fmt.Println()
+		fmt.Println("By model:")
+		// Sort by count descending for readability.
+		type modelCount struct {
+			Name  string
+			Count int
+		}
+		mc := make([]modelCount, 0, len(models))
+		for k, v := range models {
+			mc = append(mc, modelCount{k, v})
+		}
+		sort.Slice(mc, func(i, j int) bool { return mc[i].Count > mc[j].Count })
+		for _, m := range mc {
+			fmt.Printf("  %-30s  %d\n", m.Name, m.Count)
+		}
+	}
+
+	if len(sessions) > 0 {
+		fmt.Println()
+		fmt.Println("By session (top 20):")
+		type sessCount struct {
+			ID    string
+			Count int
+		}
+		sc := make([]sessCount, 0, len(sessions))
+		for k, v := range sessions {
+			sc = append(sc, sessCount{k, v})
+		}
+		sort.Slice(sc, func(i, j int) bool { return sc[i].Count > sc[j].Count })
+		if len(sc) > 20 {
+			sc = sc[:20]
+		}
+		for _, s := range sc {
+			label := s.ID
+			if label == "" {
+				label = "(no session)"
+			}
+			fmt.Printf("  %-40s  %d\n", label, s.Count)
+		}
+	}
+
+	return nil
+}
+
+// cmdRAGPurge drops every embedding tied to a session id.
+func cmdRAGPurge(args []string) error {
+	fs := flag.NewFlagSet("rag purge", flag.ContinueOnError)
+	session := fs.String("session", "", "session id to purge (required)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *session == "" {
+		return fmt.Errorf("--session required")
+	}
+
+	db, err := storage.Open(paths.StateDB())
+	if err != nil {
+		return fmt.Errorf("open db: %w", err)
+	}
+	defer db.Close()
+
+	n, err := db.DeleteEmbeddingsBySession(*session)
+	if err != nil {
+		return fmt.Errorf("rag purge: %w", err)
+	}
+	fmt.Printf("Deleted %d embedding row(s) for session %s\n", n, *session)
+	return nil
+}
+
+// ragStatsQuery aggregates the rag_embeddings table into per-
+// session + per-model counts. Pulled out as a helper so tests can
+// run it directly against an in-memory storage.DB without spawning
+// the CLI process.
+func ragStatsQuery(db *storage.DB) (sessions, models map[string]int, total int, err error) {
+	rows, qerr := db.RawDB().Query(
+		`SELECT IFNULL(session_id,''), model FROM rag_embeddings`)
+	if qerr != nil {
+		return nil, nil, 0, qerr
+	}
+	defer rows.Close()
+	sessions = map[string]int{}
+	models = map[string]int{}
+	for rows.Next() {
+		var sid, model string
+		if scanErr := rows.Scan(&sid, &model); scanErr != nil {
+			return nil, nil, 0, scanErr
+		}
+		sessions[sid]++
+		models[model]++
+		total++
+	}
+	return sessions, models, total, rows.Err()
+}

--- a/cmd/pan-agent/rag_test.go
+++ b/cmd/pan-agent/rag_test.go
@@ -1,0 +1,254 @@
+package main
+
+import (
+	"bytes"
+	"database/sql"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/euraika-labs/pan-agent/internal/storage"
+)
+
+// captureStdoutRAG runs fn with os.Stdout redirected + returns the
+// captured bytes. Local copy of the helper from tools_test.go (both
+// PRs land independently; the duplication will dedupe in a follow-up
+// once one merges first). Drains the pipe concurrently so a fn that
+// writes more than the pipe buffer (4KB on Windows) doesn't deadlock.
+func captureStdoutRAG(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+
+	var buf bytes.Buffer
+	copyDone := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(&buf, r)
+		close(copyDone)
+	}()
+
+	runErr := fn()
+	_ = w.Close()
+	<-copyDone
+	os.Stdout = old
+	return buf.String(), runErr
+}
+
+// Phase 13 WS#13.B — `pan-agent rag` CLI tests.
+//
+// The aggregation helper ragStatsQuery runs against a real
+// *storage.DB so the SQL is exercised end-to-end. Dispatch +
+// flag parsing get separate coverage.
+
+// openTempDB returns a fresh storage.DB backed by a per-test
+// temp file. PAN_AGENT_HOME is also overridden so any indirect
+// path reads point at the temp directory.
+func openTempDB(t *testing.T) *storage.DB {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("PAN_AGENT_HOME", dir)
+	db, err := storage.Open(filepath.Join(dir, "state.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// seedEmbedding writes one row into rag_embeddings via the public
+// UpsertEmbedding API. ContentHash + SourceID are randomised per
+// call so duplicate seeds don't collide on the UNIQUE constraint.
+func seedEmbedding(t *testing.T, db *storage.DB, sessionID, model, sourceID string) {
+	t.Helper()
+	row := storage.Embedding{
+		Source: "msg", SourceID: sourceID,
+		ContentHash: "hash-" + sourceID,
+		Text:        "text-" + sourceID,
+		Model:       model,
+		Dim:         4,
+		Vector:      make([]byte, 16),
+	}
+	if sessionID != "" {
+		row.SessionID = sql.NullString{String: sessionID, Valid: true}
+	}
+	if err := db.UpsertEmbedding(row); err != nil {
+		t.Fatalf("UpsertEmbedding: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// dispatch
+// ---------------------------------------------------------------------------
+
+func TestCmdRAG_NoAction(t *testing.T) {
+	if err := cmdRAG(nil); err == nil {
+		t.Error("expected missing-action error")
+	}
+}
+
+func TestCmdRAG_UnknownAction(t *testing.T) {
+	if err := cmdRAG([]string{"banana"}); err == nil ||
+		!strings.Contains(err.Error(), "unknown") {
+		t.Errorf("got %v, want unknown-action error", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ragStatsQuery (the aggregation helper)
+// ---------------------------------------------------------------------------
+
+func TestRAGStatsQuery_Empty(t *testing.T) {
+	db := openTempDB(t)
+	sessions, models, total, err := ragStatsQuery(db)
+	if err != nil {
+		t.Fatalf("ragStatsQuery: %v", err)
+	}
+	if total != 0 {
+		t.Errorf("total = %d, want 0", total)
+	}
+	if len(sessions) != 0 {
+		t.Errorf("sessions = %v, want empty", sessions)
+	}
+	if len(models) != 0 {
+		t.Errorf("models = %v, want empty", models)
+	}
+}
+
+func TestRAGStatsQuery_Aggregates(t *testing.T) {
+	db := openTempDB(t)
+	// 3 rows in sess-A under model-X
+	seedEmbedding(t, db, "sess-A", "model-X", "id-1")
+	seedEmbedding(t, db, "sess-A", "model-X", "id-2")
+	seedEmbedding(t, db, "sess-A", "model-X", "id-3")
+	// 2 rows in sess-B under model-Y
+	seedEmbedding(t, db, "sess-B", "model-Y", "id-4")
+	seedEmbedding(t, db, "sess-B", "model-Y", "id-5")
+	// 1 row with no session under model-Y
+	seedEmbedding(t, db, "", "model-Y", "id-6")
+
+	sessions, models, total, err := ragStatsQuery(db)
+	if err != nil {
+		t.Fatalf("ragStatsQuery: %v", err)
+	}
+	if total != 6 {
+		t.Errorf("total = %d, want 6", total)
+	}
+	if sessions["sess-A"] != 3 {
+		t.Errorf("sess-A = %d, want 3", sessions["sess-A"])
+	}
+	if sessions["sess-B"] != 2 {
+		t.Errorf("sess-B = %d, want 2", sessions["sess-B"])
+	}
+	if sessions[""] != 1 {
+		t.Errorf("(no session) = %d, want 1", sessions[""])
+	}
+	if models["model-X"] != 3 {
+		t.Errorf("model-X = %d, want 3", models["model-X"])
+	}
+	if models["model-Y"] != 3 {
+		t.Errorf("model-Y = %d, want 3", models["model-Y"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// stats output
+// ---------------------------------------------------------------------------
+
+func TestCmdRAGStats_EmptyDB(t *testing.T) {
+	openTempDB(t)
+	out, err := captureStdoutRAG(t, func() error {
+		return cmdRAGStats(nil)
+	})
+	if err != nil {
+		t.Fatalf("stats: %v", err)
+	}
+	if !strings.Contains(out, "0 row") {
+		t.Errorf("output should mention 0 rows: %s", out)
+	}
+	if !strings.Contains(out, "PAN_AGENT_RAG_EMBEDDER_URL") {
+		t.Errorf("output should hint at the env var: %s", out)
+	}
+}
+
+func TestCmdRAGStats_PopulatedDB(t *testing.T) {
+	db := openTempDB(t)
+	seedEmbedding(t, db, "sess-1", "model-A", "x1")
+	seedEmbedding(t, db, "sess-1", "model-A", "x2")
+	seedEmbedding(t, db, "sess-2", "model-B", "x3")
+
+	out, err := captureStdoutRAG(t, func() error {
+		return cmdRAGStats(nil)
+	})
+	if err != nil {
+		t.Fatalf("stats: %v", err)
+	}
+	if !strings.Contains(out, "3 row") {
+		t.Errorf("expected '3 row' in output: %s", out)
+	}
+	if !strings.Contains(out, "By model:") {
+		t.Errorf("expected 'By model:' header: %s", out)
+	}
+	if !strings.Contains(out, "model-A") || !strings.Contains(out, "model-B") {
+		t.Errorf("expected both models listed: %s", out)
+	}
+	if !strings.Contains(out, "sess-1") || !strings.Contains(out, "sess-2") {
+		t.Errorf("expected both sessions listed: %s", out)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// purge
+// ---------------------------------------------------------------------------
+
+func TestCmdRAGPurge_RequiresSession(t *testing.T) {
+	openTempDB(t)
+	if err := cmdRAGPurge(nil); err == nil ||
+		!strings.Contains(err.Error(), "session required") {
+		t.Errorf("got %v, want session-required error", err)
+	}
+}
+
+func TestCmdRAGPurge_DeletesByID(t *testing.T) {
+	db := openTempDB(t)
+	seedEmbedding(t, db, "sess-A", "m", "id-1")
+	seedEmbedding(t, db, "sess-A", "m", "id-2")
+	seedEmbedding(t, db, "sess-B", "m", "id-3")
+
+	out, err := captureStdoutRAG(t, func() error {
+		return cmdRAGPurge([]string{"--session=sess-A"})
+	})
+	if err != nil {
+		t.Fatalf("purge: %v", err)
+	}
+	if !strings.Contains(out, "Deleted 2") {
+		t.Errorf("expected 'Deleted 2' in output: %s", out)
+	}
+
+	// Confirm sess-B intact.
+	rest, err := db.ListEmbeddingsBySession("sess-B")
+	if err != nil {
+		t.Fatalf("ListEmbeddingsBySession: %v", err)
+	}
+	if len(rest) != 1 {
+		t.Errorf("sess-B affected: %d rows remain", len(rest))
+	}
+}
+
+func TestCmdRAGPurge_NoMatch(t *testing.T) {
+	openTempDB(t)
+	out, err := captureStdoutRAG(t, func() error {
+		return cmdRAGPurge([]string{"--session=nope"})
+	})
+	if err != nil {
+		t.Fatalf("purge no-match: %v", err)
+	}
+	if !strings.Contains(out, "Deleted 0") {
+		t.Errorf("expected 'Deleted 0': %s", out)
+	}
+}


### PR DESCRIPTION
## Summary

Operational CLI for the WS#13.B semantic-search index. Power users can inspect what's indexed + drop a session's rows without spinning up the desktop UI.

\`\`\`
pan-agent rag stats              # counts per session + per-model totals
pan-agent rag purge --session=X  # delete every embedding tied to one session
\`\`\`

## Behaviour

### \`stats\`
Aggregates \`rag_embeddings\` rows. Prints total + a by-model breakdown (sorted by count) + the top-20 sessions. Empty-DB output hints at \`PAN_AGENT_RAG_EMBEDDER_URL\` so the user knows what to set to enable indexing.

### \`purge\`
Calls \`storage.DeleteEmbeddingsBySession\` + reports the row count. \`--session\` is required.

\`pan-agent rag reindex\` (delete-and-rebuild) is **intentionally out of scope** — re-embedding is heavy and should run inside the gateway's watcher with its rate-limit + checkpoint logic, not from a fire-and-forget CLI.

## Test plan

9 new tests:
- Dispatch: missing action, unknown action
- \`ragStatsQuery\`: empty DB, populated DB with 3 sessions × 2 models
- \`stats\` output: empty-hint mentions env var; populated output includes \"By model:\" header + both models + both sessions + correct total count
- \`purge\`: requires \`--session\` flag; deletes by id (sess-B unaffected by sess-A purge); no-match prints \"Deleted 0\"

\`go test ./...\` — 692/692 pass. \`golangci-lint run ./cmd/pan-agent/\` — 0 issues.

## Note on test helper

Local \`captureStdoutRAG\` is a copy of the helper from #65's \`tools_test.go\` — both PRs land independently; the duplication dedupes in a follow-up. Both copies use the same concurrent-drain pattern that fixed the Windows pipe-buffer deadlock seen on #65.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)